### PR TITLE
fix: Grant elasticloadbalancing:ModifyListener to devops role

### DIFF
--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -81,6 +81,7 @@
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyTargetGroupAttributes",
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:CreateTargetGroup",


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

We need this when making changes to the ACM certificate which may modify the listener.