### PR TITLE
feat: s3 bucket policy to allow cross-account read-write access

### DIFF
--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -42,6 +42,15 @@ variable "additional_s3_read_only_principals" {
   default = []
 }
 
+variable "s3_read_write_principals" {
+  type        = list(string)
+  description = <<-EOT
+    List of principals to grant read and write access to Tecton S3 bucket.
+    Typically the AWS account running the materilization jobs
+  EOT
+  default     = []
+}
+
 variable "additional_offline_storage_tags" {
   type        = map(string)
   description = "Additional tags for offline storage (S3 bucket)"
@@ -75,4 +84,3 @@ variable "kms_key_additional_principals" {
   description = "Additional set of principals to grant KMS key access to"
   default     = []
 }
-


### PR DESCRIPTION
Add the ability to grant read-write s3 access to cross account principals as bucket policy. The main use case is Rift, where the Ray workers running in control plane that cannot get permissions through AssumeRole

Cherrypicked from https://github.com/tecton-ai/tecton/commit/3b8fffc7eadb2b920d0b450b9b08511b81293cee