### PR TITLE
Configure DB Migrator IAM role and permissions

### DIFF
--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -148,7 +148,7 @@ resource "aws_iam_policy" "devops_fargate_policy" {
   tags   = local.tags
 }
 
-# DEVOPS [Common : Databricks and EMR]
+# Database Migrator [Common : Databricks and EMR]
 data "template_file" "database_migrator_policy_json" {
   template = file("${path.module}/../templates/database_migrator_policy.json")
   vars = {

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -172,11 +172,6 @@ resource "aws_iam_policy" "database_migrator_policy" {
   tags   = local.tags
 }
 
-resource "aws_iam_role_policy_attachment" "database_migrator_policy_to_db_migrator_role" {
-  role       = aws_iam_role.database_migrator.name
-  policy_arn = aws_iam_policy.database_migrator_policy.arn
-}
-
 resource "aws_iam_role_policy_attachment" "database_migrator_policy_to_eks_node_role" {
   role       = aws_iam_role.eks_node_role.name
   policy_arn = aws_iam_policy.database_migrator_policy.arn

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -153,7 +153,6 @@ data "template_file" "database_migrator_policy_json" {
   template = file("${path.module}/../templates/database_migrator_policy.json")
   vars = {
     ACCOUNT_ID      = var.account_id
-    DEPLOYMENT_NAME = var.deployment_name
     REGION          = var.region
   }
 }

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -158,7 +158,7 @@ data "template_file" "database_migrator_policy_json" {
   }
 }
 
-# DEVOPS [Common : Databricks and EMR]
+# Database Migrator [Common : Databricks and EMR]
 resource "aws_iam_role" "database_migrator" {
   name               = "tecton-${var.deployment_name}-database-migrator"
   tags               = local.tags

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -165,7 +165,7 @@ resource "aws_iam_role" "database_migrator" {
   assume_role_policy = var.external_id != "" ? data.template_file.assume_role_external_id_policy.rendered : data.template_file.assume_role_policy.rendered
 }
 
-# DEVOPS [Common : Databricks and EMR]
+# Database Migrator [Common : Databricks and EMR]
 resource "aws_iam_policy" "database_migrator_policy" {
   name   = "tecton-${var.deployment_name}-database-migrator"
   policy = data.template_file.database_migrator_policy_json.rendered

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -148,6 +148,40 @@ resource "aws_iam_policy" "devops_fargate_policy" {
   tags   = local.tags
 }
 
+# DEVOPS [Common : Databricks and EMR]
+data "template_file" "database_migrator_policy_json" {
+  template = file("${path.module}/../templates/database_migrator_policy.json")
+  vars = {
+    ACCOUNT_ID      = var.account_id
+    DEPLOYMENT_NAME = var.deployment_name
+    REGION          = var.region
+  }
+}
+
+# DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_role" "database_migrator" {
+  name               = "tecton-${var.deployment_name}-database-migrator"
+  tags               = local.tags
+  assume_role_policy = var.external_id != "" ? data.template_file.assume_role_external_id_policy.rendered : data.template_file.assume_role_policy.rendered
+}
+
+# DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_policy" "database_migrator_policy" {
+  name   = "tecton-${var.deployment_name}-database-migrator"
+  policy = data.template_file.database_migrator_policy_json.rendered
+  tags   = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "database_migrator_policy_to_db_migrator_role" {
+  role       = aws_iam_role.database_migrator.name
+  policy_arn = aws_iam_policy.database_migrator_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "database_migrator_policy_to_eks_node_role" {
+  role       = aws_iam_role.eks_node_role.name
+  policy_arn = aws_iam_policy.database_migrator_policy.arn
+}
+
 # EKS [Common : Databricks and EMR]
 data "template_file" "devops_eks_policy_json" {
   template = file("${path.module}/../templates/devops_eks_policy.json")

--- a/templates/database_migrator_policy.json
+++ b/templates/database_migrator_policy.json
@@ -4,28 +4,15 @@
         {
             "Sid": "RdsSnapshotAccess",
             "Action": [
-                "rds:CopyDBClusterSnapshot",
-                "rds:CopyDBSnapshot",
-                "rds:CreateDBClusterSnapshot",
                 "rds:CreateDBSnapshot",
-                "rds:DeleteDBClusterSnapshot",
-                "rds:DeleteDBSnapshot",
-                "rds:DescribeDBClusterSnapshots",
-                "rds:DescribeDBClusters",
                 "rds:DescribeDBInstances",
-                "rds:DescribeDBSnapshots",
-                "rds:ModifyDBClusterSnapshotAttribute",
-                "rds:ModifyDBSnapshot",
-                "rds:ModifyDBSnapshotAttribute"
+                "rds:DescribeDBSnapshots"
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:*",
-                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-snapshot:*",
                 "arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:*",
-                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:og:default*",
-                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot:*",
-                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot-tenant-database:*:*"
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot:database-migrator-pre-migration-*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot-tenant-database:database-migrator-pre-migration-*:*"
             ]
         }
     ]

--- a/templates/database_migrator_policy.json
+++ b/templates/database_migrator_policy.json
@@ -1,0 +1,32 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "RdsSnapshotAccess",
+            "Action": [
+                "rds:CopyDBClusterSnapshot",
+                "rds:CopyDBSnapshot",
+                "rds:CreateDBClusterSnapshot",
+                "rds:CreateDBSnapshot",
+                "rds:DeleteDBClusterSnapshot",
+                "rds:DeleteDBSnapshot",
+                "rds:DescribeDBClusterSnapshots",
+                "rds:DescribeDBClusters",
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBSnapshots",
+                "rds:ModifyDBClusterSnapshotAttribute",
+                "rds:ModifyDBSnapshot",
+                "rds:ModifyDBSnapshotAttribute"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster:*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:cluster-snapshot:*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:db:*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:og:default*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot:*",
+                "arn:aws:rds:${REGION}:${ACCOUNT_ID}:snapshot-tenant-database:*:*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds an IAM role and ensuing permissions necessary for running the database migrator. The role is used by the Kubernetes Service Account, while the `db-migrator` pod uses the `tecton-<cluster name>-eks-worker-role` IAM role under the hood. Therefore, the `tecton-<cluster name>-database-migrator` IAM role only needs the assume role policy, but no actual permissions, while the `tecton-<cluster name>-eks-worker-role` IAM role requires the RDS snapshot permissions needed to perform the database migration. The RDS snapshot permissions were based off of the permissions currently used for SaaS clusters. This was successfully tested on an internal cluster.

This PR will not be merged until we begin the rollout plan.