### PR TITLE
chore: a few tweaks

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "my-region"
+  region = "us-west-2"
 }
 
 # this example assumes that Databricks and Tecton are deployed to the same account
@@ -17,8 +17,8 @@ locals {
   deployment_name = "my-deployment-name"
 
   # The region and account_id of this Tecton account you just created
-  region     = "my-region"
-  account_id = "123456789"
+  region     = "us-west-2"
+  account_id = "1234567890"
 
   # Name of role and instance profile used by Databricks
   spark_role_name             = "my-spark-role-name"
@@ -28,6 +28,9 @@ locals {
 
   # Get from your Tecton rep
   tecton_assuming_account_id = "123456789"
+
+  # OPTIONAL to also enable Rift. Get from your Tecton rep
+  # tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
 }
 
 resource "random_id" "external_id" {
@@ -43,4 +46,6 @@ module "tecton" {
   cross_account_external_id  = resource.random_id.external_id.id
 
   databricks_spark_role_name = local.spark_role_name
+  # OPTIONAL to also enable Rift
+  # s3_read_write_principals   = [local.tecton_control_plane_root_principal]
 }

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -8,7 +8,7 @@ output "spark_role_name" {
   value = local.spark_role_name
 }
 output "spark_role_arn" {
-  value = var.use_rift_ca_policy ? null : data.aws_iam_role.spark_role[0].arn
+  value = var.use_rift_cross_account_policy ? null : data.aws_iam_role.spark_role[0].arn
 }
 output "emr_master_role_name" {
   value = var.create_emr_roles ? aws_iam_role.emr_master_role[0].name : null

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 data "aws_iam_role" "spark_role" {
-  count = var.use_rift_ca_policy ? 0 : 1
+  count = var.use_rift_cross_account_policy ? 0 : 1
   name = var.create_emr_roles ? aws_iam_role.emr_spark_role[0].name : var.databricks_spark_role_name
 }
 
@@ -35,7 +35,7 @@ resource "aws_iam_role" "cross_account_role" {
 POLICY
 }
 resource "aws_iam_policy" "cross_account_policy_spark" {
-  count = var.use_rift_ca_policy ? 0 : 1
+  count = var.use_rift_cross_account_policy ? 0 : 1
 
   name = "tecton-${var.deployment_name}-cross-account-policy"
   policy = templatefile("${path.module}/../templates/ca_policy.json", {
@@ -49,7 +49,7 @@ resource "aws_iam_policy" "cross_account_policy_spark" {
 
 
 resource "aws_iam_policy" "cross_account_policy_rift" {
-  count = var.use_rift_ca_policy ? 1 : 0
+  count = var.use_rift_cross_account_policy ? 1 : 0
 
   name = "tecton-${var.deployment_name}-cross-account-policy"
   policy = templatefile("${path.module}/../templates/rift_ca_policy.json", {
@@ -61,7 +61,7 @@ resource "aws_iam_policy" "cross_account_policy_rift" {
 }
 
 locals {
-  cross_account_policy_arn = var.use_rift_ca_policy ? aws_iam_policy.cross_account_policy_rift[0].arn : aws_iam_policy.cross_account_policy_spark[0].arn
+  cross_account_policy_arn = var.use_rift_cross_account_policy ? aws_iam_policy.cross_account_policy_rift[0].arn : aws_iam_policy.cross_account_policy_spark[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "cross_account_policy_attachment" {
@@ -71,7 +71,7 @@ resource "aws_iam_role_policy_attachment" "cross_account_policy_attachment" {
 
 # SPARK ROLE
 resource "aws_iam_policy" "common_spark_policy" {
-  count = var.use_rift_ca_policy ? 0 : 1
+  count = var.use_rift_cross_account_policy ? 0 : 1
 
   name = "tecton-${var.deployment_name}-common-spark-policy"
   policy = templatefile("${path.module}/../templates/spark_policy.json", {
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "common_spark_policy" {
   tags = local.tags
 }
 resource "aws_iam_role_policy_attachment" "common_spark_policy_attachment" {
-  count = var.use_rift_ca_policy ? 0 : 1
+  count = var.use_rift_cross_account_policy ? 0 : 1
 
   policy_arn = aws_iam_policy.common_spark_policy[0].arn
   role       = local.spark_role_name

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -85,7 +85,7 @@ variable "kms_key_additional_principals" {
   default     = []
 }
 
-variable "use_rift_ca_policy" {
+variable "use_rift_cross_account_policy" {
   type        = bool
   description = "Whether or not to use rift version of IAM policies for cross-account access"
   default     = false

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "this-accounts-region"
+  region     = "us-west-2"
 }
 
 locals {
@@ -17,11 +17,14 @@ locals {
   deployment_name = "my-deployment-name"
 
   # The region and account_id of this Tecton account you just created
-  region     = "my-region"
+  region     = "us-west-2"
   account_id = "1234567890"
 
-  # Get this values from your Tecton rep
-  tecton_assuming_account_id = "1234567890"
+  # Get from your Tecton rep
+  tecton_assuming_account_id = "123456789"
+
+  # OPTIONAL to also enable Rift. Get from your Tecton rep
+  # tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
 
   # OPTIONAL for EMR notebook clusters in a different account (see optional block at end of file)
   # cross_account_arn = "arn:aws:iam::9876543210:root"
@@ -40,6 +43,9 @@ module "tecton" {
   cross_account_external_id  = random_id.external_id.id
 
   create_emr_roles = true
+
+  # OPTIONAL to also enable Rift
+  # s3_read_write_principals   = [local.tecton_control_plane_root_principal]
 }
 
 module "security_groups" {

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -18,10 +18,13 @@ locals {
 
   # The region and account_id of this Tecton account you just created
   region     = "us-west-2"
-  account_id = "123456789"
+  account_id = "1234567890"
 
   # Get from your Tecton rep
-  tecton_control_plane_root_principal = "arn:aws:iam::123456789:root"
+  tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
+
+  # Get from your Tecton rep
+  tecton_assuming_account_id = "123456789"
 }
 
 resource "random_id" "external_id" {
@@ -29,13 +32,14 @@ resource "random_id" "external_id" {
 }
 
 module "tecton" {
-  source                    = "../deployment"
-  deployment_name           = local.deployment_name
-  account_id                = local.account_id
-  region                    = local.region
-  cross_account_external_id = resource.random_id.external_id.id
+  source                     = "../deployment"
+  deployment_name            = local.deployment_name
+  account_id                 = local.account_id
+  region                     = local.region
+  cross_account_external_id  = resource.random_id.external_id.id
+  tecton_assuming_account_id = local.tecton_assuming_account_id
 
   # Control plane root principal
-  s3_read_write_principals = [local.tecton_control_plane_root_principal]
-  use_rift_ca_policy       = true
+  s3_read_write_principals      = [local.tecton_control_plane_root_principal]
+  use_rift_cross_account_policy = true
 }


### PR DESCRIPTION
### What
1. variable rename `use_rift_ca_policy` -> `use_rift_cross_account_policy`
2. Added the code to optionally enable rift for databricks and emr
3. make account id and region consistent across examples.