### PR TITLE
chore: make s3_read_write_principals mandatory

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -27,10 +27,7 @@ locals {
   databricks_workspace = "mycompany.cloud.databricks.com"
 
   # Get from your Tecton rep
-  tecton_assuming_account_id = "123456789"
-
-  # OPTIONAL to also enable Rift. Get from your Tecton rep
-  # tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
+  tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
 }
 
 resource "random_id" "external_id" {
@@ -41,11 +38,9 @@ module "tecton" {
   source                     = "../deployment"
   deployment_name            = local.deployment_name
   account_id                 = local.account_id
-  tecton_assuming_account_id = local.tecton_assuming_account_id
   region                     = local.region
   cross_account_external_id  = resource.random_id.external_id.id
 
   databricks_spark_role_name = local.spark_role_name
-  # OPTIONAL to also enable Rift
-  # s3_read_write_principals   = [local.tecton_control_plane_root_principal]
+  s3_read_write_principals   = [local.tecton_control_plane_root_principal]
 }

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -7,6 +7,15 @@ variable "account_id" {
 variable "region" {
   type = string
 }
+
+variable "s3_read_write_principals" {
+  type        = list(string)
+  description = <<-EOT
+    List of principals to grant read and write access to Tecton S3 bucket.
+    Typically the AWS account running the materilization jobs
+  EOT
+}
+
 variable "satellite_region" {
   type    = string
   default = null
@@ -40,15 +49,6 @@ variable "emr_read_ecr_repositories" {
 variable "additional_s3_read_only_principals" {
   type    = list(string)
   default = []
-}
-
-variable "s3_read_write_principals" {
-  type        = list(string)
-  description = <<-EOT
-    List of principals to grant read and write access to Tecton S3 bucket.
-    Typically the AWS account running the materilization jobs
-  EOT
-  default     = []
 }
 
 variable "additional_offline_storage_tags" {

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -21,10 +21,7 @@ locals {
   account_id = "1234567890"
 
   # Get from your Tecton rep
-  tecton_assuming_account_id = "123456789"
-
-  # OPTIONAL to also enable Rift. Get from your Tecton rep
-  # tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
+  tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
 
   # OPTIONAL for EMR notebook clusters in a different account (see optional block at end of file)
   # cross_account_arn = "arn:aws:iam::9876543210:root"
@@ -38,14 +35,12 @@ module "tecton" {
   source                     = "../deployment"
   deployment_name            = local.deployment_name
   account_id                 = local.account_id
-  tecton_assuming_account_id = local.tecton_assuming_account_id
   region                     = local.region
   cross_account_external_id  = random_id.external_id.id
 
   create_emr_roles = true
 
-  # OPTIONAL to also enable Rift
-  # s3_read_write_principals   = [local.tecton_control_plane_root_principal]
+  s3_read_write_principals   = [local.tecton_control_plane_root_principal]
 }
 
 module "security_groups" {

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -22,9 +22,6 @@ locals {
 
   # Get from your Tecton rep
   tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
-
-  # Get from your Tecton rep
-  tecton_assuming_account_id = "123456789"
 }
 
 resource "random_id" "external_id" {
@@ -37,7 +34,6 @@ module "tecton" {
   account_id                 = local.account_id
   region                     = local.region
   cross_account_external_id  = resource.random_id.external_id.id
-  tecton_assuming_account_id = local.tecton_assuming_account_id
 
   # Control plane root principal
   s3_read_write_principals      = [local.tecton_control_plane_root_principal]


### PR DESCRIPTION
1. make `s3_read_write_principals` mandatory which in turns enables Rift by default
2. remove `tecton_assuming_account_id` because it we use the default value already.