### PR TITLE
chore: Adds VPC Endpoint Security Group Name Variable

### DIFF
--- a/privatelink/cross_vpc/README.md
+++ b/privatelink/cross_vpc/README.md
@@ -71,11 +71,12 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | DNS name for Tecton servcies | `string` | n/a | yes |
-| <a name="input_vpc_endpoint_security_group_egress_cidrs"></a> [vpc\_endpoint\_security\_group\_egress\_cidrs](#input\_vpc\_endpoint\_security\_group\_egress\_cidrs) | Egress CIDR blocks of the VPC endpiont security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| <a name="input_vpc_endpoint_security_group_ingress_cidrs"></a> [vpc\_endpoint\_security\_group\_ingress\_cidrs](#input\_vpc\_endpoint\_security\_group\_ingress\_cidrs) | Ingress CIDR blocks of the VPC endpiont security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_vpc_endpoint_security_group_egress_cidrs"></a> [vpc\_endpoint\_security\_group\_egress\_cidrs](#input\_vpc\_endpoint\_security\_group\_egress\_cidrs) | Egress CIDR blocks of the VPC endpoint security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_vpc_endpoint_security_group_ingress_cidrs"></a> [vpc\_endpoint\_security\_group\_ingress\_cidrs](#input\_vpc\_endpoint\_security\_group\_ingress\_cidrs) | Ingress CIDR blocks of the VPC endpoint security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_vpc_endpoint_service_name"></a> [vpc\_endpoint\_service\_name](#input\_vpc\_endpoint\_service\_name) | Name of the pre-existing VPC endpoint service to connect to | `string` | n/a | yes |
-| <a name="input_vpc_endpoint_subnet_ids"></a> [vpc\_endpoint\_subnet\_ids](#input\_vpc\_endpoint\_subnet\_ids) | Private subnet ids where to create VPC endpiont | `list(string)` | n/a | yes |
+| <a name="input_vpc_endpoint_subnet_ids"></a> [vpc\_endpoint\_subnet\_ids](#input\_vpc\_endpoint\_subnet\_ids) | Private subnet ids where to create VPC endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID from which to create the VPC endpoint | `string` | n/a | yes |
+| <a name="input_vpc_endpoint_security_group_name"></a> [vpc\_endpoint\_security\_group\_name](#input\_vpc\_endpoint\_security\_group\_name) | Name of the VPC endpoint security group | `string` | `"tecton-services-vpc-endpoint"` | no |
 
 ## Outputs
 

--- a/privatelink/cross_vpc/main.tf
+++ b/privatelink/cross_vpc/main.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "cross_vpc_vpc_endpoint" {
-  name        = "tecton-services-vpc-endpoint"
+  name        = var.vpc_endpoint_security_group_name
   description = "Security group for the accessing Tecton services by cross-vpc vpc endpoint"
   vpc_id      = var.vpc_id
 

--- a/privatelink/cross_vpc/variables.tf
+++ b/privatelink/cross_vpc/variables.tf
@@ -14,18 +14,24 @@ variable "vpc_endpoint_service_name" {
 }
 
 variable "vpc_endpoint_subnet_ids" {
-  description = "Private subnet ids where to create VPC endpiont"
+  description = "Private subnet ids where to create VPC endpoint"
   type        = list(string)
 }
 
+variable "vpc_endpoint_security_group_name" {
+  description = "Name of the VPC endpoint security group"
+  type        = string
+  default     = "tecton-services-vpc-endpoint"
+}
+
 variable "vpc_endpoint_security_group_ingress_cidrs" {
-  description = "Ingress CIDR blocks of the VPC endpiont security group"
+  description = "Ingress CIDR blocks of the VPC endpoint security group"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "vpc_endpoint_security_group_egress_cidrs" {
-  description = "Egress CIDR blocks of the VPC endpiont security group"
+  description = "Egress CIDR blocks of the VPC endpoint security group"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
## What

This introduces a `vpc_endpoint_security_group_name` variable, making naming of the underlying security group more flexible. The variable in turn retains the previous hardcoded value as its default to ensure there are no ensuing changes to associated configurations.

This pull request also fixes three minor typos.

## Why

This change allows for deployment flexibility.