### PR TITLE
chore: external_id provided by tecton rep

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -28,10 +28,9 @@ locals {
 
   # Get from your Tecton rep
   tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
-}
 
-resource "random_id" "external_id" {
-  byte_length = 16
+  # Get from your Tecton rep
+  cross_account_external_id = "tecton-external-id"
 }
 
 module "tecton" {
@@ -39,7 +38,7 @@ module "tecton" {
   deployment_name            = local.deployment_name
   account_id                 = local.account_id
   region                     = local.region
-  cross_account_external_id  = resource.random_id.external_id.id
+  cross_account_external_id  = local.cross_account_external_id
 
   databricks_spark_role_name = local.spark_role_name
   s3_read_write_principals   = [local.tecton_control_plane_root_principal]

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  region     = "us-west-2"
+  region = "us-west-2"
 }
 
 locals {
@@ -23,24 +23,23 @@ locals {
   # Get from your Tecton rep
   tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
 
+  # get from your tecton rep
+  cross_account_external_id = "tecton-external-id"
+
   # OPTIONAL for EMR notebook clusters in a different account (see optional block at end of file)
   # cross_account_arn = "arn:aws:iam::9876543210:root"
 }
 
-resource "random_id" "external_id" {
-  byte_length = 16
-}
-
 module "tecton" {
-  source                     = "../deployment"
-  deployment_name            = local.deployment_name
-  account_id                 = local.account_id
-  region                     = local.region
-  cross_account_external_id  = random_id.external_id.id
+  source                    = "../deployment"
+  deployment_name           = local.deployment_name
+  account_id                = local.account_id
+  region                    = local.region
+  cross_account_external_id = local.cross_account_external_id
 
   create_emr_roles = true
 
-  s3_read_write_principals   = [local.tecton_control_plane_root_principal]
+  s3_read_write_principals = [local.tecton_control_plane_root_principal]
 }
 
 module "security_groups" {

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -22,6 +22,9 @@ locals {
 
   # Get from your Tecton rep
   tecton_control_plane_root_principal = "arn:aws:iam::987654321:root"
+
+  # get from your tecton rep
+  cross_account_external_id = "tecton-external-id"
 }
 
 resource "random_id" "external_id" {
@@ -33,7 +36,7 @@ module "tecton" {
   deployment_name            = local.deployment_name
   account_id                 = local.account_id
   region                     = local.region
-  cross_account_external_id  = resource.random_id.external_id.id
+  cross_account_external_id  = local.cross_account_external_id
 
   # Control plane root principal
   s3_read_write_principals      = [local.tecton_control_plane_root_principal]


### PR DESCRIPTION
Make external_id provided by Tecton. There are a few reasons to do this:
1. This smooths out cluster creation process as control plane is created first now
2. Follows the [best practice provided by AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) that external_id should be provided by the client