### PR TITLE
fix: add missing local variable

### DIFF
--- a/databricks_sample/outputs.tf
+++ b/databricks_sample/outputs.tf
@@ -8,7 +8,7 @@ output "cross_account_role_arn" {
   value = module.tecton.cross_account_role_arn
 }
 output "cross_account_external_id" {
-  value = resource.random_id.external_id.id
+  value = local.cross_account_external_id
 }
 output "spark_role_name" {
   value = local.spark_role_name

--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -6,6 +6,10 @@ resource "aws_s3_bucket" "tecton" {
   }
 }
 
+locals {
+  kms_key_arn = (var.kms_key_id != null) ? format("arn:aws:kms:%s:%s:key/%s", var.region, var.account_id, var.kms_key_id) : null
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "tecton_s3_bucket_encryption_configuration" {
   bucket = aws_s3_bucket.tecton.id
 
@@ -13,7 +17,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tecton_s3_bucket_
     bucket_key_enabled = var.bucket_sse_algorithm == "aws:kms" ? var.bucket_sse_key_enabled : null
 
     apply_server_side_encryption_by_default {
-      sse_algorithm = var.bucket_sse_algorithm
+      sse_algorithm     = var.bucket_sse_algorithm
+      kms_master_key_id = local.kms_key_arn
     }
   }
 }

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -8,7 +8,7 @@ output "cross_account_role_arn" {
   value = module.tecton.cross_account_role_arn
 }
 output "cross_account_external_id" {
-  value = resource.random_id.external_id.id
+  value = local.cross_account_external_id
 }
 output "spark_role_arn" {
   value = module.tecton.spark_role_arn

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -27,10 +27,6 @@ locals {
   cross_account_external_id = "tecton-external-id"
 }
 
-resource "random_id" "external_id" {
-  byte_length = 16
-}
-
 module "tecton" {
   source                     = "../deployment"
   deployment_name            = local.deployment_name

--- a/rift_sample/outputs.tf
+++ b/rift_sample/outputs.tf
@@ -8,7 +8,7 @@ output "cross_account_role_arn" {
   value = module.tecton.cross_account_role_arn
 }
 output "cross_account_external_id" {
-  value = resource.random_id.external_id.id
+  value = local.cross_account_external_id
 }
 
 output "kms_key_arn" {


### PR DESCRIPTION
A couple of bug fixes
1. make sure `kms_key_id` defaults to null
2. Pipe `local.cross_account_external_id` to output