### PR TITLE
Add emr import table permissions to eks policy

### DIFF
--- a/templates/eks_policy.json
+++ b/templates/eks_policy.json
@@ -18,7 +18,7 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
-                "dynamodb:UpdateTable",
+                "dynamodb:UpdateTable"
             ],
             "Resource": [
                 "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"

--- a/templates/eks_policy.json
+++ b/templates/eks_policy.json
@@ -11,12 +11,14 @@
                 "dynamodb:CreateTable",
                 "dynamodb:DeleteItem",
                 "dynamodb:DeleteTable",
+                "dynamodb:DescribeImport",
                 "dynamodb:DescribeTable",
                 "dynamodb:GetItem",
+                "dynamodb:ImportTable",
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
-                "dynamodb:UpdateTable"
+                "dynamodb:UpdateTable",
             ],
             "Resource": [
                 "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"
@@ -72,6 +74,23 @@
             ],
             "Resource": [
                 "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+            ]
+        },
+        {
+            "Sid": "CloudwatchLogging",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:*",
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:log-stream:*",
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group::log-stream:*"
             ]
         }
     ]


### PR DESCRIPTION
Allow eks to call the dynamo import table api. This is in addition to ["135",](https://github.com/tecton-ai/tecton-terraform-setup/pull/135) which adds ImportTable support to vpc deployments.