### PR TITLE
feat: separate flags controlling spark and rift iam resources [DVOPS-1809]

### DIFF
--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -8,7 +8,7 @@ output "spark_role_name" {
   value = local.spark_role_name
 }
 output "spark_role_arn" {
-  value = var.use_rift_cross_account_policy ? null : data.aws_iam_role.spark_role[0].arn
+  value = local.use_spark_compute ? data.aws_iam_role.spark_role[0].arn : null
 }
 output "emr_master_role_name" {
   value = var.create_emr_roles ? aws_iam_role.emr_master_role[0].name : null

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -3,7 +3,7 @@ locals {
   spark_role_name = var.create_emr_roles ? aws_iam_role.emr_spark_role[0].name : var.databricks_spark_role_name
   # Include var.use_rift_cross_account_policy for backward compatibility
   use_rift_compute_on_control_plane = var.use_rift_compute_on_control_plane || var.use_rift_cross_account_policy
-  use_spark_compute                 = var.use_spark_compute || !var.use_rift_cross_account_policy
+  use_spark_compute                 = var.use_spark_compute && (var.use_rift_cross_account_policy == false)
 }
 
 data "aws_iam_role" "spark_role" {

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "aws_iam_role" "spark_role" {
-  count = local.use_spark_compute ? 0 : 1
+  count = local.use_spark_compute ? 1 : 0
   name  = var.create_emr_roles ? aws_iam_role.emr_spark_role[0].name : var.databricks_spark_role_name
 }
 
@@ -78,10 +78,6 @@ resource "aws_iam_policy" "cross_account_policy_rift" {
     REGION          = var.region
   })
   tags = local.tags
-}
-
-locals {
-  cross_account_policy_arn = var.use_rift_cross_account_policy ? aws_iam_policy.cross_account_policy_rift[0].arn : aws_iam_policy.cross_account_policy_spark[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "spark_cross_account_policy_attachment" {

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -3,7 +3,7 @@ locals {
   spark_role_name = var.create_emr_roles ? aws_iam_role.emr_spark_role[0].name : var.databricks_spark_role_name
   # Include var.use_rift_cross_account_policy for backward compatibility
   use_rift_compute_on_control_plane = var.use_rift_compute_on_control_plane || var.use_rift_cross_account_policy
-  use_spark_compute                 = var.use_spark_compute && (var.use_rift_cross_account_policy == false)
+  use_spark_compute                 = var.use_spark_compute && (var.use_rift_cross_account_policy != true)
 }
 
 data "aws_iam_role" "spark_role" {

--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -2,7 +2,7 @@ locals {
   tags            = { "tecton-accessible:${var.deployment_name}" : "true" }
   spark_role_name = var.create_emr_roles ? aws_iam_role.emr_spark_role[0].name : var.databricks_spark_role_name
   # Include var.use_rift_cross_account_policy for backward compatibility
-  use_rift_compute_on_control_plane = var.use_rift_compute_on_control_plane || var.use_rift_cross_account_policy
+  use_rift_compute_on_control_plane = var.use_rift_compute_on_control_plane || (var.use_rift_cross_account_policy == true)
   use_spark_compute                 = var.use_spark_compute && (var.use_rift_cross_account_policy != true)
 }
 

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -88,7 +88,8 @@ variable "kms_key_additional_principals" {
 variable "use_rift_cross_account_policy" {
   type        = bool
   description = "(Deprecated in favor of var.use_rift_compute_on_control_plane) Whether or not to use rift version of IAM policies for cross-account access"
-  default     = false
+  default     = null
+  nullable    = true
 }
 
 variable "use_rift_compute_on_control_plane" {

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -87,8 +87,20 @@ variable "kms_key_additional_principals" {
 
 variable "use_rift_cross_account_policy" {
   type        = bool
-  description = "Whether or not to use rift version of IAM policies for cross-account access"
+  description = "(Deprecated in favor of var.use_rift_compute_on_control_plane) Whether or not to use rift version of IAM policies for cross-account access"
   default     = false
+}
+
+variable "use_rift_compute_on_control_plane" {
+  type        = bool
+  description = "Whether or not to enable Rift compute on control plane"
+  default     = false
+}
+
+variable "use_spark_compute" {
+  type        = bool
+  description = "Whether or not to enable Spark compute"
+  default     = true
 }
 
 variable "cross_account_role_allow_sts_metadata" {

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -45,7 +45,7 @@ module "tecton" {
 
   # Control plane root principal
   s3_read_write_principals      = [format("arn:aws:iam::%s:root", local.tecton_control_plane_account_id)]
-  use_rift_cross_account_policy = true
+  use_rift_compute_on_control_plane = !local.enable_rift_on_data_plane
 }
 
 module "rift" {

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -44,8 +44,9 @@ module "tecton" {
   tecton_assuming_account_id = local.tecton_control_plane_account_id
 
   # Control plane root principal
-  s3_read_write_principals      = [format("arn:aws:iam::%s:root", local.tecton_control_plane_account_id)]
+  s3_read_write_principals          = [format("arn:aws:iam::%s:root", local.tecton_control_plane_account_id)]
   use_rift_compute_on_control_plane = !local.enable_rift_on_data_plane
+  use_spark_compute                 = false # Set to true if also enable Spark compute
 }
 
 module "rift" {


### PR DESCRIPTION
Previously, we use a single variable `use_rift_cross_account_policy` to toggle between using Rift and Spark compute cross-account policy. This is no longer sufficient after we introduce rift on data plane. Now, we have to differentiate between:
- rift on control plane
- rift on data plane
- spark

This PR introduces to separate flags to control:
1. enablement of rift on control plane: `use_rift_compute_on_control_plane`
2. enablement of spark: `use_spark_compute`

The 4 different combinations of these two flags are:
- #1 on, #2 on: enable both rift on control plane and spark
- #1 on, #2 off: enable rift on control plane
- #1 off, #2 on: enable spark
- #1 off, #2 off: enable rift on data plane (must also include `rift` module)
