### PR TITLE
fix: Update dynamo cross account role with new time to live roles

### DIFF
--- a/templates/ca_policy.json
+++ b/templates/ca_policy.json
@@ -19,7 +19,8 @@
                 "dynamodb:Query",
                 "dynamodb:TagResource",
                 "dynamodb:UpdateTable",
-                "dynamodb:UpdateTimeToLive"
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:DescribeTimeToLive"
             ],
             "Resource": [
                 "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"

--- a/templates/rift_ca_policy.json
+++ b/templates/rift_ca_policy.json
@@ -18,7 +18,9 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
-                "dynamodb:UpdateTable"
+                "dynamodb:UpdateTable",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:DescribeTimeToLive"
             ],
             "Resource": [
                 "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"

--- a/templates/satellite_ca_policy.json
+++ b/templates/satellite_ca_policy.json
@@ -18,7 +18,9 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
-                "dynamodb:UpdateTable"
+                "dynamodb:UpdateTable",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:DescribeTimeToLive"
             ],
             "Resource": [
                 "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*",


### PR DESCRIPTION
Also add these missing roles to rift and satellite deployment