### PR TITLE
Additional permissions to allow creating/deleting network interfaces for Rift VMs

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -49,12 +49,32 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:network-interface/*",
+    ]
+    # deny unless the resource will be tagged w/ tecton_rift_workflow_id
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/tecton_rift_workflow_id"
+      values   = ["false"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "ec2:DeleteNetworkInterface",
     ]
     resources = [
       "arn:aws:ec2:*:*:network-interface/*",
     ]
-    # TODO: restrict based on tags
+    # deny unless the resource is tagged w/ tecton_rift_workflow_id
+    condition {
+      test     = "Null"
+      variable = "ec2:ResourceTag/tecton_rift_workflow_id"
+      values   = ["false"]
+    }
   }
 
   statement {

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -46,6 +46,28 @@ data "aws_iam_policy_document" "manage_rift_compute" {
   }
 
   statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:network-interface/*",
+    ]
+    # TODO: restrict based on tags
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface",
+    ]
+    resources = [
+      [for subnet in aws_subnet.private : subnet.arn],
+    ]
+  }
+
+  statement {
     effect    = "Allow"
     actions   = ["iam:PassRole"]
     resources = [aws_iam_role.rift_compute.arn]
@@ -72,6 +94,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "ec2:DescribeReservedInstancesOfferings",
       "ec2:DescribeSpotInstanceRequests",
       "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeNetworkInterfaces",
       "ssm:GetParameters"
     ]
     resources = ["*"]


### PR DESCRIPTION
This change is required to begin spinning up network interfaces for Rift compute jobs at runtime: https://github.com/tecton-ai/tecton/pull/24504