### PR TITLE
feat: reduce down the permissions required by Rift VM

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
       "arn:aws:ec2:*:${local.account_id}:volume/*",
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
-      # TODO: should we stop using the default security group?
+      # TODO: Stop using the default security group once orchestrator change is in place
       #aws_security_group.rift_compute.arn,
       "arn:aws:ec2:*:${local.account_id}:security-group/${aws_vpc.rift.default_security_group_id}",
       [for subnet in aws_subnet.private : subnet.arn],

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     ]
     resources = flatten([
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
-      "arn:aws:ec2:*:${local.account_id}:volumne/*",
+      "arn:aws:ec2:*:${local.account_id}:volume/*",
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       # TODO: should we stop using the default security group?
       #aws_security_group.rift_compute.arn,

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -55,7 +55,9 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     actions = [
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceStatus",
-      "ec2:DescribeNetworkInterfaces"
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:CreateTags",
+      "ec2:DeleteTags"
     ]
     # Describe* permissions do not support resource-level permissions:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -54,7 +54,8 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     effect = "Allow"
     actions = [
       "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus"
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeNetworkInterfaces"
     ]
     # Describe* permissions do not support resource-level permissions:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html
@@ -82,6 +83,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface"
     ]
     resources = [
       "arn:aws:ec2:*:${local.account_id}:network-interface/*"
@@ -224,26 +226,6 @@ resource "aws_iam_policy" "rift_compute_logs" {
           format("%s/*", var.s3_log_destination)
         ]
       }
-    ]
-  })
-}
-
-resource "aws_iam_policy" "rift_compute" {
-  name = lookup(var.resource_name_overrides, "rift_compute", "tecton-rift-compute")
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket",
-          "s3:GetObject"
-        ]
-        Resource = [
-          var.control_plane_bucket_destination,
-          format("%s/*", var.control_plane_bucket_destination)
-        ]
-      },
     ]
   })
 }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -77,7 +77,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
   statement {
     effect = "Allow"
     actions = [
-      "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface"
     ]
     resources = [
@@ -86,6 +85,21 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     condition {
       test     = "Null"
       variable = "ec2:ResourceTag/tecton_rift_workflow_id"
+      values   = ["false"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface"
+    ]
+    resources = [
+      "arn:aws:ec2:*:${local.account_id}:network-interface/*"
+    ]
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/tecton_rift_workflow_id"
       values   = ["false"]
     }
   }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -71,6 +71,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     ]
     resources = flatten([
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
+      "arn:aws:ec2:*:${local.account_id}:volumne/*",
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       # TODO: should we stop using the default security group?
       #aws_security_group.rift_compute.arn,

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -184,7 +184,8 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
           "dynamodb:DescribeTable",
           "dynamodb:GetItem",
           "dynamodb:PutItem",
-          "dynamodb:UpdateItem"
+          "dynamodb:UpdateItem",
+          "dynamodb:Query"
         ]
         Resource = [
           "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*",

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -201,8 +201,7 @@ resource "aws_iam_policy" "rift_ecr_readonly" {
     Statement = [
       {
         Effect = "Allow"
-        Action = [ # TODO: scope this down + test
-          "ecr:GetAuthorizationToken",
+        Action = [
           "ecr:BatchCheckLayerAvailability",
           "ecr:GetDownloadUrlForLayer",
           "ecr:GetRepositoryPolicy",
@@ -218,6 +217,13 @@ resource "aws_iam_policy" "rift_ecr_readonly" {
         Resource = [
           aws_ecr_repository.rift_env.arn
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = ["*"]
       }
     ]
   })

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -187,7 +187,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
           "dynamodb:UpdateItem"
         ]
         Resource = [
-          "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*_job_metadata",
+          "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*",
         ]
       }
     ]

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     resources = ["*"]
     condition {
       test     = "Null"
-      variable = "ec2:ResourceTag/tecton_rift_workflow_id"
+      variable = "ec2:RequestTag/tecton_rift_workflow_id"
       values   = ["false"]
     }
   }
@@ -100,10 +100,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     actions = [
       "ec2:CreateNetworkInterface",
     ]
-    resources = flatten([
-      aws_security_group.rift_compute.arn,
-      [for subnet in aws_subnet.private : subnet.arn],
-    ])
+    resources = [aws_security_group.rift_compute.arn]
   }
 
   statement {

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -71,6 +71,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     ]
     resources = flatten([
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
+      "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       aws_security_group.rift_compute.arn,
       [for subnet in aws_subnet.private : subnet.arn],
     ])

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -72,7 +72,9 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     resources = flatten([
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
-      aws_security_group.rift_compute.arn,
+      # TODO: should we stop using the default security group?
+      #aws_security_group.rift_compute.arn,
+      aws_vpc.rift.default_security_group_id
       [for subnet in aws_subnet.private : subnet.arn],
     ])
   }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       # TODO: should we stop using the default security group?
       #aws_security_group.rift_compute.arn,
-      aws_vpc.rift.default_security_group_id,
+      "arn:aws:ec2:*:${local.account_id}:security-group/${aws_vpc.rift.default_security_group_id}",
       [for subnet in aws_subnet.private : subnet.arn],
     ])
   }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       # TODO: should we stop using the default security group?
       #aws_security_group.rift_compute.arn,
-      aws_vpc.rift.default_security_group_id
+      aws_vpc.rift.default_security_group_id,
       [for subnet in aws_subnet.private : subnet.arn],
     ])
   }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -83,7 +83,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     effect = "Allow"
     actions = [
       "ec2:CreateNetworkInterface",
-      "ec2:AttachNetworkInterface"
     ]
     resources = [
       "arn:aws:ec2:*:${local.account_id}:network-interface/*"

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -187,7 +187,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
           "dynamodb:UpdateItem"
         ]
         Resource = [
-          "arn:aws:dynamodb:*:${local.account_id}:table/tecton-${var.cluster_name}_job_metadata",
+          "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*_job_metadata",
         ]
       }
     ]

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -313,7 +313,6 @@ resource "aws_iam_policy" "rift_compute_internal" {
 
 locals {
   rift_compute_policies = {
-    rift_compute         = aws_iam_policy.rift_compute,
     rift_compute_logs    = aws_iam_policy.rift_compute_logs,
     offline_store_access = aws_iam_policy.offline_store_access,
     dynamo_db_access     = aws_iam_policy.rift_dynamodb_access,

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -293,6 +293,20 @@ resource "aws_iam_policy" "offline_store_access" {
         Resource = [
           format("%s/%s", var.offline_store_bucket_arn, "internal/*"),
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject"
+        ]
+        Resource = ["*"]
+        # Allow access to public S3 buckets
+        Condition = {
+          "StringNotEquals" = {
+            "s3:ResourceAccount" : local.account_id
+          }
+        }
       }
     ]
   })

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -60,11 +60,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     # Describe* permissions do not support resource-level permissions:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html
     resources = ["*"]
-    condition {
-      test     = "Null"
-      variable = "ec2:RequestTag/tecton_rift_workflow_id"
-      values   = ["false"]
-    }
   }
 
   statement {
@@ -100,7 +95,10 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     actions = [
       "ec2:CreateNetworkInterface",
     ]
-    resources = [aws_security_group.rift_compute.arn]
+    resources = flatten([
+      aws_security_group.rift_compute.arn,
+      [for subnet in aws_subnet.private : subnet.arn],
+    ])
   }
 
   statement {

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -75,7 +75,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
       aws_security_group.rift_compute.arn,
       [for subnet in aws_subnet.private : subnet.arn],
-      "arn:aws:ec2:*:${local.account_id}:network-interface/tecton-rift-*", 
     ])
   }
 

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -35,6 +35,11 @@ variable "subnet_azs" {
   description = "List of AZs to create subnets in."
 }
 
+variable "control_plane_bucket_destination" {
+  type        = string
+  description = "ARN of the Tecton control plane bucket, which hosts materialization parameters"
+}
+
 variable "tecton_vpce_service_name" {
   type        = string
   default     = null

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -35,11 +35,6 @@ variable "subnet_azs" {
   description = "List of AZs to create subnets in."
 }
 
-variable "control_plane_bucket_destination" {
-  type        = string
-  description = "ARN of the Tecton control plane bucket, which hosts materialization parameters"
-}
-
 variable "tecton_vpce_service_name" {
   type        = string
   default     = null


### PR DESCRIPTION
### Summary 
Scope down list of permissions to run Rift on data plane

### Test plan
test on `tecton-dev-ops2` once orchestrator changes are in 