### PR TITLE
Adjust Rift permissions for NICs and AMIs

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -71,7 +71,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     ]
     resources = flatten([
       "arn:aws:ec2:*:${local.account_id}:volume/*",
-      "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       aws_security_group.rift_compute.arn,
       # TODO (BAT-14731): Stop using the default security group once orchestrator change is in place
       "arn:aws:ec2:*:${local.account_id}:security-group/${aws_vpc.rift.default_security_group_id}",

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -70,7 +70,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "ec2:RunInstances",
     ]
     resources = flatten([
-      "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
       "arn:aws:ec2:*:${local.account_id}:volume/*",
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
       aws_security_group.rift_compute.arn,
@@ -120,6 +119,21 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       aws_security_group.rift_compute.arn,
       [for subnet in aws_subnet.private : subnet.arn],
     ])
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+    ]
+    resources = [
+      "arn:aws:ec2:*::image/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:Owner"
+      values   = ["amazon", "472542229217"]
+    }
   }
 
   statement {

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -83,6 +83,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
   statement {
     effect = "Allow"
     actions = [
+      "ec2:RunInstances",
       "ec2:DeleteNetworkInterface"
     ]
     resources = [


### PR DESCRIPTION
- Allow RunInstances only on NICs that are tagged w/ rift's workflow tag
- Allow RunInstances only on AMIs owned by Amazon and Tecton