### PR TITLE
Allow RunInstances on Rift security group

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -73,8 +73,8 @@ data "aws_iam_policy_document" "manage_rift_compute" {
       "arn:aws:ec2:*::image/*", # TODO: Restrict to specific AMI ARN
       "arn:aws:ec2:*:${local.account_id}:volume/*",
       "arn:aws:ec2:*:${local.account_id}:network-interface/*",
-      # TODO: Stop using the default security group once orchestrator change is in place
-      #aws_security_group.rift_compute.arn,
+      aws_security_group.rift_compute.arn,
+      # TODO (BAT-14731): Stop using the default security group once orchestrator change is in place
       "arn:aws:ec2:*:${local.account_id}:security-group/${aws_vpc.rift.default_security_group_id}",
       [for subnet in aws_subnet.private : subnet.arn],
     ])


### PR DESCRIPTION
Need to allow using this SG so we can migrate orchestrator to it. We can remove the permission to use default SG once the orchestrator change is in.