### PR TITLE
feat: support AssumeRole into cross-account intermediate role

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -210,6 +210,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
         Action = [
           "sts:AssumeRole"
         ]
+        # Used for assume into cross-account-intermediary role when Rift is in control plane account.
         Resource = ["arn:aws:iam::${local.account_id}:role/${cluster_name}-cross-account-intermediate"]
       }
     ]

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -211,7 +211,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
           "sts:AssumeRole"
         ]
         # Used for assume into cross-account-intermediary role when Rift is in control plane account.
-        Resource = ["arn:aws:iam::${local.account_id}:role/${cluster_name}-cross-account-intermediate"]
+        Resource = ["arn:aws:iam::${local.account_id}:role/${var.cluster_name}-cross-account-intermediate"]
       }
     ]
   })

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -204,6 +204,13 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
         Resource = [
           "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*",
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sts:AssumeRole"
+        ]
+        Resource = ["arn:aws:iam::${local.account_id}:role/${cluster_name}-cross-account-intermediate"]
       }
     ]
   })


### PR DESCRIPTION
### What
Add the permission to assume into the cross-account intermediary role.

### Why
The `rift_compute` module is shared by both Rift-on-control-plane and Rift-on-data-plane. Cross-account intermediary role is used when Rift runs on control plane. 