### PR TITLE
Disallow running ec2 instances in the default VPC

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -72,8 +72,6 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     resources = flatten([
       "arn:aws:ec2:*:${local.account_id}:volume/*",
       aws_security_group.rift_compute.arn,
-      # TODO (BAT-14731): Stop using the default security group once orchestrator change is in place
-      "arn:aws:ec2:*:${local.account_id}:security-group/${aws_vpc.rift.default_security_group_id}",
       [for subnet in aws_subnet.private : subnet.arn],
     ])
   }


### PR DESCRIPTION
This change makes it so that Rift VMs can only be launched in the Rift security group, not the default Rift VPC group (which has less restrictive rules).

Note: Requires corresponding orchestrator PR to be rolled out to all VM Rift clusters: https://github.com/tecton-ai/tecton/pull/25198