### PR TITLE
Take offline store kms key arn as input and add to rift compute policy.

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  use_kms_key = var.offline_store_kms_key_arn != null
+  use_kms_key = var.kms_key_arn != null
 }
 
 # rift-compute-manager role, used by orchestrator for creating/managing EC2 instances running rift materialization jobs.
@@ -342,7 +342,7 @@ resource "aws_iam_policy" "offline_store_access" {
           "kms:GenerateDataKey"
         ]
         Resource = [
-          var.offline_store_kms_key_arn
+          var.kms_key_arn
         ]
       }] : [])
   })

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -65,8 +65,8 @@ variable "additional_rift_compute_policy_statements" {
   default     = []
 }
 
-variable "offline_store_kms_key_arn" {
+variable "kms_key_arn" {
   type        = string
-  description = "ARN of KMS key used to encrypt offline feature store."
+  description = "ARN of KMS key used to encrypt online/offline feature store."
   default     = null
 }

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -64,3 +64,9 @@ variable "additional_rift_compute_policy_statements" {
   description = "Additional IAM policy statements to attach to the rift_compute role"
   default     = []
 }
+
+variable "offline_store_kms_key_arn" {
+  type        = string
+  description = "ARN of KMS key used to encrypt offline feature store."
+  default     = null
+}


### PR DESCRIPTION
In #147, `Allow` rule for `"kms:*"` on `["*"]` was removed as part of scoping down permissions. 

In order for rift compute to be able to access encrypted offline store buckets, the IAM policy needs `"kms:Decrypt", "kms:GenerateDataKey"` for the kms key used to encrypt the offline store. Adding that key's arn as an input variable to the module here `offline_store_kms_key_arn`, and incorporating into the `offline_store_access` policy.

(DVOPS-1879)