### PR TITLE
Add NAT gateway IPs for rift-compute vpc as output list.

### DIFF
--- a/rift_compute/outputs.tf
+++ b/rift_compute/outputs.tf
@@ -25,3 +25,8 @@ output "anyscale_docker_target_repo" {
   # input for kustomization.yaml: `ANYSCALE_DOCKER_TARGET_REPO`
   value = aws_ecr_repository.rift_env.repository_url
 }
+
+output "nat_gateway_public_ips" {
+  description = "List of public IPs associated with the NAT Gateways"
+  value       = [for eip in aws_eip.rift : eip.public_ip]
+}


### PR DESCRIPTION
Adding NAT IPs for rift-compute VPC as output here, so they can be incorporated into rules for allowing ingress from rift compute instances to the tecton control plane when restricted-ingress/IP allowlisting is enabled.

Tested with terraform plan in `eshiferax/ip-allowlist-rift` branch of main tecton repo.