### PR TITLE
Allow user to specify additional iam policy statements for rift-compute.

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -368,6 +368,14 @@ resource "aws_iam_policy" "rift_compute_internal" {
   })
 }
 
+resource "aws_iam_policy" "additional_rift_compute_policy" {
+  count = length(var.additional_rift_compute_policy_statements) > 0 ? 1 : 0
+  name  = lookup(var.resource_name_overrides, "additional_rift_compute_policy", "tecton-additional-rift-compute-policy")
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = var.additional_rift_compute_policy_statements
+  })
+}
 
 locals {
   rift_compute_policies = {
@@ -382,6 +390,12 @@ resource "aws_iam_role_policy_attachment" "rift_compute_policies" {
   for_each   = local.rift_compute_policies
   role       = aws_iam_role.rift_compute.name
   policy_arn = each.value.arn
+}
+
+resource "aws_iam_role_policy_attachment" "rift_compute_additional_policy" {
+  count      = length(var.additional_rift_compute_policy_statements) > 0 ? 1 : 0
+  role       = aws_iam_role.rift_compute.name
+  policy_arn = aws_iam_policy.additional_rift_compute_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "rift_compute_internal_policies" {

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -58,3 +58,9 @@ variable "enable_custom_model" {
   default     = false
   description = "If should grant worker node access to read model artifacts from s3. Still WIP and by default it doesn't."
 }
+
+variable "additional_rift_compute_policy_statements" {
+  type        = list(any)
+  description = "Additional IAM policy statements to attach to the rift_compute role"
+  default     = []
+}


### PR DESCRIPTION
(DVOPS-1877) Adding a variable `additional_rift_compute_policy_statements` to allow user to specify a list of IAM statements to be attached to a policy on the rift-compute role.


Test plan output on `tecton-dev-ops-dataplane` pointing to this branch, with the following variable input added to `rift` module (just an example, not actually adding this policy anywhere):
```hcl
module "rift" {
  # ..other inputs
  additional_rift_compute_policy_statements = [
    {
      Effect    = "Allow"
      Action    = ["s3:*"]
      Resource  = "*"
    }
  ]
}
```

plan output corresponding to this change:
```hcl
  # module.rift.aws_iam_policy.additional_rift_compute_policy[0] will be created
  + resource "aws_iam_policy" "additional_rift_compute_policy" {
      + arn         = (known after apply)
      + id          = (known after apply)
      + name        = "tecton-additional-rift-compute-policy"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:*",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = (known after apply)
    }


...

  # module.rift.aws_iam_role_policy_attachment.rift_compute_additional_policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "rift_compute_additional_policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "tecton-rift-compute"
    }
```