### PR TITLE
[wip] Restrict egress on rift_compute security-group to known destinations + allow extension.

### DIFF
--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -63,7 +63,8 @@ resource "aws_security_group_rule" "rift_compute_egress" {
   cidr_blocks       = var.apply_egress_restrictions ? concat(
     [for ip in local.chronosphere_ips : "${ip}/32"],
     [for ip in local.fluentbit_ips : "${ip}/32"],
-    var.tecton_control_plane_cidr_blocks) : ["0.0.0.0/0"]
+    var.tecton_control_plane_cidr_blocks,
+    var.additional_egress_cidr_blocks) : ["0.0.0.0/0"]
   from_port         = "-1"
   to_port           = "-1"
   protocol          = "-1"

--- a/rift_compute/outputs.tf
+++ b/rift_compute/outputs.tf
@@ -30,3 +30,7 @@ output "nat_gateway_public_ips" {
   description = "List of public IPs associated with the NAT Gateways"
   value       = [for eip in aws_eip.rift : eip.public_ip]
 }
+
+output "rift_compute_security_group_id" {
+  value = aws_security_group.rift_compute.id
+}

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -62,11 +62,17 @@ variable "enable_custom_model" {
 variable "tecton_control_plane_cidr_blocks" {
   type        = list(string)
   default     = []
-  description = "CIDR blocks for the NLB that serves the Tecton Control Plane."
+  description = "CIDR blocks for the Tecton Control Plane."
 }
 
 variable "apply_egress_restrictions" {
   type        = bool
   default     = false
   description = "If true, will apply egress restrictions to rift-compute"
+}
+
+variable "additional_egress_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "Additional CIDR blocks to allow egress to."
 }

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -58,3 +58,9 @@ variable "enable_custom_model" {
   default     = false
   description = "If should grant worker node access to read model artifacts from s3. Still WIP and by default it doesn't."
 }
+
+variable "tecton_control_plane_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "CIDR blocks for the NLB that serves the Tecton Control Plane."
+}

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -64,3 +64,9 @@ variable "tecton_control_plane_cidr_blocks" {
   default     = []
   description = "CIDR blocks for the NLB that serves the Tecton Control Plane."
 }
+
+variable "apply_egress_restrictions" {
+  type        = bool
+  default     = false
+  description = "If true, will apply egress restrictions to rift-compute"
+}


### PR DESCRIPTION
Adding `apply_egress_restrictions` input variable to `rift_compute` module. If set to true, `rift_compute` security-group will have egress restricted to the known destinations -- chronosphere, fluentbit-packages, and tecton control plane.

If PrivateLink is enabled, rift_compute SG will have egress rule to allow access to the local vpc-endpoint that gets created in this module.