### PR TITLE
Add options for rift_compute egress restrictions (both network_firewall for domain-based, security-group for ip-based).

### DIFF
--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -75,6 +75,7 @@ resource "aws_security_group_rule" "rift_compute_egress_gateway" {
 
 # Rule for Interface endpoints
 resource "aws_security_group_rule" "rift_compute_egress_interface" {
+  count                    = var.apply_egress_restrictions_security_group ? 1 : 0
   security_group_id        = aws_security_group.rift_compute.id
   type                     = "egress"
   from_port                = "-1"

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -9,6 +9,11 @@ locals {
     ".ecr.aws",
     ".amazonaws.com",
     ".aws.amazon.com",
+    # Crowdstrike
+    ".crowdstrike.com",
+    ".cloudsink.net",
+    ".githubusercontent.com",
+    "crowdstrike.github.io",
   ]
 
 }

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -14,6 +14,8 @@ locals {
     ".cloudsink.net",
     ".githubusercontent.com",
     "crowdstrike.github.io",
+    # Temporary -- allow all domains to troubleshoot:
+    "."
   ]
 
 }

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -3,8 +3,8 @@
 
 locals {
   default_allowed_egress_domains = [
-    format("%s.tecton.ai", var.cluster_name), # tecton control plane for this cluster
-    "tecton.chronosphere.io",                 # Metrics
+    ".tecton.ai",             # tecton control plane for this cluster
+    "tecton.chronosphere.io", # Metrics
     "packages.fluentbit.io",
     ".ecr.aws",
     ".amazonaws.com",
@@ -46,21 +46,20 @@ resource "aws_networkfirewall_firewall_policy" "rift_egress" {
     # Temporarily allow all traffic to troubleshoot
     stateful_default_actions = [
       "aws:alert_established",
-      # "aws:drop_established",
-      # "aws:pass"
+      "aws:drop_established",
     ]
     stateless_default_actions = [
-      # "aws:forward_to_sfe",
-      "aws:pass"
+      "aws:forward_to_sfe",
+      # "aws:pass"
     ]
     stateless_fragment_default_actions = ["aws:pass"]
     stateful_engine_options {
       rule_order = "STRICT_ORDER"
     }
-    # stateful_rule_group_reference {
-    #   priority     = 1
-    #   resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
-    # }
+    stateful_rule_group_reference {
+      priority     = 1
+      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    }
   }
 }
 

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -45,16 +45,24 @@ resource "aws_networkfirewall_firewall_policy" "rift_egress" {
   count = var.use_network_firewall ? 1 : 0
   name  = "tecton-rift-egress-firewall-policy"
   firewall_policy {
-    stateful_default_actions           = ["aws:alert_established", "aws:drop_established"]
-    stateless_default_actions          = ["aws:forward_to_sfe"]
+    # Temporarily allow all traffic to troubleshoot
+    stateful_default_actions = [
+      "aws:alert_established",
+      # "aws:drop_established",
+      # "aws:pass"
+    ]
+    stateless_default_actions = [
+      # "aws:forward_to_sfe",
+      "aws:pass"
+    ]
     stateless_fragment_default_actions = ["aws:pass"]
     stateful_engine_options {
       rule_order = "STRICT_ORDER"
     }
-    stateful_rule_group_reference {
-      priority     = 1
-      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
-    }
+    # stateful_rule_group_reference {
+    #   priority     = 1
+    #   resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    # }
   }
 }
 

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -14,8 +14,6 @@ locals {
     ".cloudsink.net",
     ".githubusercontent.com",
     "crowdstrike.github.io",
-    # Temporary -- allow all domains to troubleshoot:
-    "."
   ]
 
 }

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -80,11 +80,11 @@ resource "aws_networkfirewall_rule_group" "rift_compute_egress_allowed_domains" 
 module "firewall_subnet_cidrs" {
   source          = "hashicorp/subnets/cidr"
   version         = "1.0.0"
-  base_cidr_block = local.vpc_cidr
-  networks = [for az in var.subnet_azs :
+  base_cidr_block = "10.0.24.0/22"  # Start from the next available /22 block
+  networks = [for i, az in var.subnet_azs :
     {
       name     = "firewall-${az}"
-      new_bits = floor((32 - local.base_cidr_mask) / length(var.subnet_azs)) + 2
+      new_bits = 2  # This will create /24 subnets within the /22 block
     }
   ]
 }

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -46,20 +46,20 @@ resource "aws_networkfirewall_firewall_policy" "rift_egress" {
     # Temporarily allow all traffic to troubleshoot
     stateful_default_actions = [
       "aws:alert_established",
-      # "aws:drop_established",
+      "aws:drop_established",
     ]
     stateless_default_actions = [
-      # "aws:forward_to_sfe",
-      "aws:pass"
+      "aws:forward_to_sfe",
+      # "aws:pass"
     ]
     stateless_fragment_default_actions = ["aws:pass"]
     stateful_engine_options {
       rule_order = "STRICT_ORDER"
     }
-    # stateful_rule_group_reference {
-    #   priority     = 1
-    #   resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
-    # }
+    stateful_rule_group_reference {
+      priority     = 1
+      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    }
   }
 }
 

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -1,0 +1,163 @@
+# Restricts egress from rift compute to only allowed domains.
+# Activated with var.use_network_firewall = true
+
+locals {
+  default_allowed_egress_domains = [
+    format("%s.tecton.ai", var.cluster_name), # tecton control plane for this cluster
+    "tecton.chronosphere.io",                 # Metrics
+    "packages.fluentbit.io",
+    ".ecr.aws",
+    ".amazonaws.com",
+    ".aws.amazon.com",
+  ]
+
+}
+
+resource "aws_networkfirewall_firewall" "rift_egress" {
+  count                    = var.use_network_firewall ? 1 : 0
+  delete_protection        = false
+  firewall_policy_arn      = aws_networkfirewall_firewall_policy.rift_egress[0].arn
+  name                     = "tecton-rift-egress-firewall"
+  subnet_change_protection = false
+  tags                     = {}
+  tags_all                 = {}
+  vpc_id                   = aws_vpc.rift.id
+
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.firewall_subnet
+    content {
+      subnet_id       = subnet_mapping.value.id
+      ip_address_type = "IPV4"
+    }
+  }
+
+}
+
+
+resource "aws_networkfirewall_firewall_policy" "rift_egress" {
+  count = var.use_network_firewall ? 1 : 0
+  name  = "tecton-rift-egress-firewall-policy"
+  firewall_policy {
+    stateful_default_actions           = ["aws:alert_established", "aws:drop_established"]
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:pass"]
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+    stateful_rule_group_reference {
+      priority     = 1
+      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    }
+  }
+}
+
+
+resource "aws_networkfirewall_rule_group" "rift_compute_egress_allowed_domains" {
+  count    = var.use_network_firewall ? 1 : 0
+  capacity = 500
+  name     = "egress-allowed-domains-rift"
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_string = null
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST", "TLS_SNI"]
+        targets              = concat(local.default_allowed_egress_domains, var.additional_allowed_egress_domains)
+      }
+    }
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}
+
+module "firewall_subnet_cidrs" {
+  source          = "hashicorp/subnets/cidr"
+  version         = "1.0.0"
+  base_cidr_block = local.vpc_cidr
+  networks = [for az in var.subnet_azs :
+    {
+      name     = "firewall-${az}"
+      new_bits = floor((32 - local.base_cidr_mask) / length(var.subnet_azs)) + 2
+    }
+  ]
+}
+
+resource "aws_subnet" "firewall_subnet" {
+  for_each = var.use_network_firewall ? module.firewall_subnet_cidrs.network_cidr_blocks : {}
+  vpc_id            = aws_vpc.rift.id
+  availability_zone = split("-", each.key)[1]
+  cidr_block        = each.value
+  tags = {
+    Name = format("tecton-rift-firewall-%s", each.key)
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_route_table" "firewall_route_table" {
+  count  = var.use_network_firewall ? 1 : 0
+  vpc_id = aws_vpc.rift.id
+  tags = {
+    Name = "tecton-rift-firewall-route-table"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_route_table" "igw_route_table" {
+  count  = var.use_network_firewall ? 1 : 0
+  vpc_id = aws_vpc.rift.id
+  tags = {
+    Name = "tecton-rift-firewall-igw-route-table"
+  }
+
+
+}
+
+resource "aws_route_table_association" "igw_route_table_assoc" {
+  count          = var.use_network_firewall ? 1 : 0
+  gateway_id     = aws_internet_gateway.rift.id
+  route_table_id = aws_route_table.igw_route_table[0].id
+}
+
+resource "aws_route_table_association" "firewall_subnet_route_table_association" {
+  for_each       = aws_subnet.firewall_subnet
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.firewall_route_table[0].id
+}
+
+locals {
+  networkfirewall_endpoints = var.use_network_firewall ? {
+    for i in aws_networkfirewall_firewall.rift_egress[0].firewall_status[0].sync_states :
+    i.availability_zone => i.attachment[0].endpoint_id
+  } : {}
+}
+
+# Route internet traffic to firewall from public subnet
+resource "aws_route" "public_subnet_route_to_firewall" {
+  count                  = var.use_network_firewall ? 1 : 0
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  vpc_endpoint_id        = local.networkfirewall_endpoints[keys(local.networkfirewall_endpoints)[0]]
+}
+
+# Route internet traffic back to firewall from igw
+resource "aws_route" "igw_route_to_firewall_to_public_subnet" {
+  for_each               = var.use_network_firewall ? aws_subnet.public : {}
+  route_table_id         = aws_route_table.igw_route_table[0].id
+  destination_cidr_block = each.value.cidr_block
+  vpc_endpoint_id        = local.networkfirewall_endpoints[keys(local.networkfirewall_endpoints)[0]]
+}
+
+# Route outgoing internet traffic to igw from firewall
+resource "aws_route" "firewall_route_to_igw" {
+  count                  = var.use_network_firewall ? 1 : 0
+  route_table_id         = aws_route_table.firewall_route_table[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.rift.id
+}

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -92,7 +92,7 @@ module "firewall_subnet_cidrs" {
 resource "aws_subnet" "firewall_subnet" {
   for_each = var.use_network_firewall ? module.firewall_subnet_cidrs.network_cidr_blocks : {}
   vpc_id            = aws_vpc.rift.id
-  availability_zone = split("-", each.key)[1]
+  availability_zone = join("-", slice(split("-", each.key), 1, length(split("-", each.key))))
   cidr_block        = each.value
   tags = {
     Name = format("tecton-rift-firewall-%s", each.key)

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -46,20 +46,20 @@ resource "aws_networkfirewall_firewall_policy" "rift_egress" {
     # Temporarily allow all traffic to troubleshoot
     stateful_default_actions = [
       "aws:alert_established",
-      "aws:drop_established",
+      # "aws:drop_established",
     ]
     stateless_default_actions = [
-      "aws:forward_to_sfe",
-      # "aws:pass"
+      # "aws:forward_to_sfe",
+      "aws:pass"
     ]
     stateless_fragment_default_actions = ["aws:pass"]
     stateful_engine_options {
       rule_order = "STRICT_ORDER"
     }
-    stateful_rule_group_reference {
-      priority     = 1
-      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
-    }
+    # stateful_rule_group_reference {
+    #   priority     = 1
+    #   resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    # }
   }
 }
 

--- a/rift_compute/outputs.tf
+++ b/rift_compute/outputs.tf
@@ -30,3 +30,7 @@ output "nat_gateway_public_ips" {
   description = "List of public IPs associated with the NAT Gateways"
   value       = [for eip in aws_eip.rift : eip.public_ip]
 }
+
+output "rift_compute_security_group_id" {
+  value = aws_security_group.rift_compute.id
+}

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -70,3 +70,34 @@ variable "kms_key_arn" {
   description = "ARN of KMS key used to encrypt online/offline feature store."
   default     = null
 }
+
+variable "tecton_control_plane_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "CIDR blocks for the Tecton Control Plane."
+}
+
+variable "apply_egress_restrictions_security_group" {
+  type        = bool
+  default     = false
+  description = "If true, will apply egress restrictions to rift-compute security group (IP-based)"
+}
+
+variable "additional_egress_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "Additional CIDR blocks to allow egress to (if using restricted egress security group)."
+}
+
+variable "use_network_firewall" {
+  type        = bool
+  default     = false
+  description = "If true, will use AWS Network Firewall to restrict egress."
+}
+
+variable "additional_allowed_egress_domains" {
+  type        = list(string)
+  default     = []
+  description = "Additional domains to allow egress to (if using network firewall)"
+}
+

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -127,6 +127,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint" "ecr" {
+  count = var.apply_egress_restrictions_security_group ? 1 : 0
   vpc_id       = aws_vpc.rift.id
   service_name = format("com.amazonaws.%s.ecr.dkr", data.aws_region.current.name)
   vpc_endpoint_type = "Interface"
@@ -135,6 +136,7 @@ resource "aws_vpc_endpoint" "ecr" {
 }
 
 resource "aws_vpc_endpoint" "ecr_api" {
+  count        = var.apply_egress_restrictions_security_group ? 1 : 0
   vpc_id       = aws_vpc.rift.id
   service_name = format("com.amazonaws.%s.ecr.api", data.aws_region.current.name)
   vpc_endpoint_type = "Interface"
@@ -143,6 +145,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
 }
 
 resource "aws_vpc_endpoint" "kms" {
+  count        = var.apply_egress_restrictions_security_group ? 1 : 0
   vpc_id       = aws_vpc.rift.id
   service_name = format("com.amazonaws.%s.kms", data.aws_region.current.name)
   vpc_endpoint_type = "Interface"

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -63,6 +63,7 @@ resource "aws_nat_gateway" "rift" {
 }
 
 resource "aws_route" "internet_gateway" {
+  count = var.use_network_firewall ? 0 : 1
   route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.rift.id
@@ -125,6 +126,30 @@ resource "aws_vpc_endpoint" "s3" {
   service_name = format("com.amazonaws.%s.s3", data.aws_region.current.name)
 }
 
+resource "aws_vpc_endpoint" "ecr" {
+  vpc_id       = aws_vpc.rift.id
+  service_name = format("com.amazonaws.%s.ecr.dkr", data.aws_region.current.name)
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+  security_group_ids = [aws_security_group.aws_vpc_endpoints_security_group.id]
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id       = aws_vpc.rift.id
+  service_name = format("com.amazonaws.%s.ecr.api", data.aws_region.current.name)
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+  security_group_ids = [aws_security_group.aws_vpc_endpoints_security_group.id]
+}
+
+resource "aws_vpc_endpoint" "kms" {
+  vpc_id       = aws_vpc.rift.id
+  service_name = format("com.amazonaws.%s.kms", data.aws_region.current.name)
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+  security_group_ids = [aws_security_group.aws_vpc_endpoints_security_group.id]
+}
+
 
 ## To enable PrivateLink connection w/Tecton VPC. Required for tecton-secrets+PrivateLink support.
 resource "aws_vpc_endpoint" "tecton_privatelink" {
@@ -142,6 +167,22 @@ resource "aws_vpc_endpoint_subnet_association" "tecton_privatelink" {
   vpc_endpoint_id = aws_vpc_endpoint.tecton_privatelink[0].id
   subnet_id       = each.value
 }
+
+resource "aws_security_group" "aws_vpc_endpoints_security_group" {
+  name        = "aws-vpc-endpoints-security-group"
+  description = "Security group applied to the vpc endpoints for aws services (e.g. dynamodb, s3) that are accessed by the rift compute VPC."
+  vpc_id      = aws_vpc.rift.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+
 
 resource "aws_security_group" "tecton_privatelink_cross_vpc" {
   count       = var.tecton_vpce_service_name != null ? 1 : 0

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -59,4 +59,16 @@ module "rift" {
   offline_store_bucket_arn                = format("arn:aws:s3:::%s", module.tecton.s3_bucket.bucket)
   subnet_azs                              = ["us-west-2a", "us-west-2b", "us-wesb-2c"]
   tecton_vpce_service_name                = local.tecton_vpce_service_name
+
+  # Egress from rift compute will be open to internet by default.
+  # To restrict egress based on known list of domains, set the following:
+  # use_network_firewall = true
+  # Domains can be extended as needed:
+  # additional_allowed_egress_domains = [...]
+
+
+  # Alternatively, to restrict egress using IP CIDR blocks (security group), set the following:
+  # apply_egress_restrictions_security_group = true
+  # This can be extended as needed:
+  # additional_egress_cidr_blocks = [...]
 }


### PR DESCRIPTION
Adding two variables to rift_compute (both default `false`):

* `use_network_firewall` -- this applies DNS-based stateful rules on a network-firewall resource created in the rift VPC. All internet traffic is routed through this firewall before IGW. The list of domains are in `local.default_allowed_egress_domains` in `network_firewall.tf`, and can be extended with  `var.additional_allowed_egress_domains`.
* `apply_egress_restrictions_security_group` -- this applies security-group egress restrictions using CIDR blocks (of known egress destinations) and VPC endpoints for aws services. Can be extended with `var.additional_egress_cidr_blocks`.

Users would choose _one_ of the above^ to set to `true`. Default behavior is the same as before (open egress).

Other changes:
* Adding interface VPC endpoints for ECR, ECR API, and KMS.
* Add output for rift_compute security group ID (needed by control-plane during cluster creation)
* Updated `rift_sample` to include new variables.