### PR TITLE
Add network-firewall option for egress restriction on rift_compute.

### DIFF
--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -52,3 +52,4 @@ resource "aws_security_group_rule" "rift_compute_egress" {
   to_port           = "-1"
   protocol          = "-1"
 }
+

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -1,0 +1,177 @@
+# Restricts egress from rift compute to only allowed domains.
+# Activated with var.use_network_firewall = true
+
+locals {
+  default_allowed_egress_domains = [
+    ".tecton.ai",             # tecton control plane for this cluster
+    "tecton.chronosphere.io", # Metrics
+    "packages.fluentbit.io",
+    ".ecr.aws",
+    ".amazonaws.com",
+    ".aws.amazon.com",
+    ".ubuntu.com",
+    ".canonical.com",
+    "api.snapcraft.io",
+    ".duckdb.org",
+    # Crowdstrike
+    ".crowdstrike.com",
+    ".cloudsink.net",
+    ".githubusercontent.com",
+    "crowdstrike.github.io",
+  ]
+
+}
+
+resource "aws_networkfirewall_firewall" "rift_egress" {
+  count                    = var.use_network_firewall ? 1 : 0
+  delete_protection        = false
+  firewall_policy_arn      = aws_networkfirewall_firewall_policy.rift_egress[0].arn
+  name                     = "tecton-rift-egress-firewall"
+  subnet_change_protection = false
+  tags                     = {}
+  tags_all                 = {}
+  vpc_id                   = aws_vpc.rift.id
+
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.firewall_subnet
+    content {
+      subnet_id       = subnet_mapping.value.id
+      ip_address_type = "IPV4"
+    }
+  }
+
+}
+
+
+resource "aws_networkfirewall_firewall_policy" "rift_egress" {
+  count = var.use_network_firewall ? 1 : 0
+  name  = "tecton-rift-egress-firewall-policy"
+  firewall_policy {
+    stateful_default_actions = [
+      "aws:alert_established",
+      "aws:drop_established",
+    ]
+    stateless_default_actions = [
+      "aws:forward_to_sfe",
+    ]
+    stateless_fragment_default_actions = ["aws:pass"]
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+    stateful_rule_group_reference {
+      priority     = 1
+      resource_arn = aws_networkfirewall_rule_group.rift_compute_egress_allowed_domains[0].arn
+    }
+  }
+}
+
+
+resource "aws_networkfirewall_rule_group" "rift_compute_egress_allowed_domains" {
+  count    = var.use_network_firewall ? 1 : 0
+  capacity = 500
+  name     = "egress-allowed-domains-rift"
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_string = null
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST", "TLS_SNI"]
+        targets              = concat(local.default_allowed_egress_domains, var.additional_allowed_egress_domains)
+      }
+    }
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}
+
+module "firewall_subnet_cidrs" {
+  source          = "hashicorp/subnets/cidr"
+  version         = "1.0.0"
+  base_cidr_block = "10.0.24.0/22"  # Start from the next available /22 block
+  networks = [for i, az in var.subnet_azs :
+    {
+      name     = "firewall-${az}"
+      new_bits = 2  # This will create /24 subnets within the /22 block
+    }
+  ]
+}
+
+resource "aws_subnet" "firewall_subnet" {
+  for_each = var.use_network_firewall ? module.firewall_subnet_cidrs.network_cidr_blocks : {}
+  vpc_id            = aws_vpc.rift.id
+  availability_zone = join("-", slice(split("-", each.key), 1, length(split("-", each.key))))
+  cidr_block        = each.value
+  tags = {
+    Name = format("tecton-rift-firewall-%s", each.key)
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_route_table" "firewall_route_table" {
+  count  = var.use_network_firewall ? 1 : 0
+  vpc_id = aws_vpc.rift.id
+  tags = {
+    Name = "tecton-rift-firewall-route-table"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_route_table" "igw_route_table" {
+  count  = var.use_network_firewall ? 1 : 0
+  vpc_id = aws_vpc.rift.id
+  tags = {
+    Name = "tecton-rift-firewall-igw-route-table"
+  }
+
+
+}
+
+resource "aws_route_table_association" "igw_route_table_assoc" {
+  count          = var.use_network_firewall ? 1 : 0
+  gateway_id     = aws_internet_gateway.rift.id
+  route_table_id = aws_route_table.igw_route_table[0].id
+}
+
+resource "aws_route_table_association" "firewall_subnet_route_table_association" {
+  for_each       = aws_subnet.firewall_subnet
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.firewall_route_table[0].id
+}
+
+locals {
+  networkfirewall_endpoints = var.use_network_firewall ? {
+    for i in aws_networkfirewall_firewall.rift_egress[0].firewall_status[0].sync_states :
+    i.availability_zone => i.attachment[0].endpoint_id
+  } : {}
+}
+
+# Route internet traffic to firewall from public subnet
+resource "aws_route" "public_subnet_route_to_firewall" {
+  count                  = var.use_network_firewall ? 1 : 0
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  vpc_endpoint_id        = local.networkfirewall_endpoints[keys(local.networkfirewall_endpoints)[0]]
+}
+
+# Route internet traffic back to firewall from igw
+resource "aws_route" "igw_route_to_firewall_to_public_subnet" {
+  for_each               = var.use_network_firewall ? aws_subnet.public : {}
+  route_table_id         = aws_route_table.igw_route_table[0].id
+  destination_cidr_block = each.value.cidr_block
+  vpc_endpoint_id        = local.networkfirewall_endpoints[keys(local.networkfirewall_endpoints)[0]]
+}
+
+# Route outgoing internet traffic to igw from firewall
+resource "aws_route" "firewall_route_to_igw" {
+  count                  = var.use_network_firewall ? 1 : 0
+  route_table_id         = aws_route_table.firewall_route_table[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.rift.id
+}

--- a/rift_compute/outputs.tf
+++ b/rift_compute/outputs.tf
@@ -30,3 +30,7 @@ output "nat_gateway_public_ips" {
   description = "List of public IPs associated with the NAT Gateways"
   value       = [for eip in aws_eip.rift : eip.public_ip]
 }
+
+output "rift_compute_security_group_id" {
+  value = aws_security_group.rift_compute.id
+}

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -70,3 +70,16 @@ variable "kms_key_arn" {
   description = "ARN of KMS key used to encrypt online/offline feature store."
   default     = null
 }
+
+variable "use_network_firewall" {
+  type        = bool
+  default     = false
+  description = "If true, will use AWS Network Firewall to restrict egress."
+}
+
+variable "additional_allowed_egress_domains" {
+  type        = list(string)
+  default     = []
+  description = "Additional domains to allow egress to (if using network firewall)"
+}
+

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -63,6 +63,7 @@ resource "aws_nat_gateway" "rift" {
 }
 
 resource "aws_route" "internet_gateway" {
+  count = var.use_network_firewall ? 0 : 1
   route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.rift.id
@@ -142,6 +143,22 @@ resource "aws_vpc_endpoint_subnet_association" "tecton_privatelink" {
   vpc_endpoint_id = aws_vpc_endpoint.tecton_privatelink[0].id
   subnet_id       = each.value
 }
+
+resource "aws_security_group" "aws_vpc_endpoints_security_group" {
+  name        = "aws-vpc-endpoints-security-group"
+  description = "Security group applied to the vpc endpoints for aws services (e.g. dynamodb, s3) that are accessed by the rift compute VPC."
+  vpc_id      = aws_vpc.rift.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+
 
 resource "aws_security_group" "tecton_privatelink_cross_vpc" {
   count       = var.tecton_vpce_service_name != null ? 1 : 0

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -144,21 +144,6 @@ resource "aws_vpc_endpoint_subnet_association" "tecton_privatelink" {
   subnet_id       = each.value
 }
 
-resource "aws_security_group" "aws_vpc_endpoints_security_group" {
-  name        = "aws-vpc-endpoints-security-group"
-  description = "Security group applied to the vpc endpoints for aws services (e.g. dynamodb, s3) that are accessed by the rift compute VPC."
-  vpc_id      = aws_vpc.rift.id
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-
-
 
 resource "aws_security_group" "tecton_privatelink_cross_vpc" {
   count       = var.tecton_vpce_service_name != null ? 1 : 0

--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -59,4 +59,11 @@ module "rift" {
   offline_store_bucket_arn                = format("arn:aws:s3:::%s", module.tecton.s3_bucket.bucket)
   subnet_azs                              = ["us-west-2a", "us-west-2b", "us-wesb-2c"]
   tecton_vpce_service_name                = local.tecton_vpce_service_name
+
+  # Egress from rift compute will be open to internet by default.
+  # To restrict egress based on known list of domains (found in rift_compute/network_firewall.tf), set the following:
+  # use_network_firewall = true
+  # Domains can be extended as needed:
+  # additional_allowed_egress_domains = [...]
+
 }


### PR DESCRIPTION
Adding  variable `use_network_firewall` -- this applies DNS-based stateful rules on a network-firewall resource created in the rift VPC. All internet traffic is routed through this firewall before IGW (`private subnet` --> `nat gateway/public subnet` --> `firewall` --> `IGW`). The list of domains are in `local.default_allowed_egress_domains` in `network_firewall.tf`, and can be extended with  `var.additional_allowed_egress_domains`.

Default behavior  (^that variable being `false`) is the same as before (open egress).

Other changes:
* Add output for rift_compute security group ID (needed by control-plane during cluster creation)
* Updated `rift_sample` to include new variables.


Tested with changes in `rift-egress-restrictions-exp` branch on main tecton repo (`dev-zeus`).