### PR TITLE
More rift-sample syntax cleanup.

### DIFF
--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -56,7 +56,7 @@ module "rift" {
   cluster_name                            = local.deployment_name
   rift_compute_manager_assuming_role_arns = [format("arn:aws:iam::%s:role/%s", local.tecton_control_plane_account_id, local.tecton_control_plane_role_name)]
   control_plane_account_id                = local.tecton_control_plane_account_id
-  s3_log_destination                      = format("%s/rift-logs", module.tecton.s3_bucket.bucket)
+  s3_log_destination                      = format("arn:aws:s3:::%s/rift-logs", module.tecton.s3_bucket.bucket)
   offline_store_bucket_arn                = format("arn:aws:s3:::%s", module.tecton.s3_bucket.bucket)
   subnet_azs                              = local.subnet_azs
   tecton_vpce_service_name                = local.tecton_vpce_service_name

--- a/rift_sample/outputs.tf
+++ b/rift_sample/outputs.tf
@@ -11,23 +11,23 @@ output "cross_account_external_id" {
   value = local.cross_account_external_id
 }
 output "compute_manager_arn" {
-  value = module.rift.compute_manager_arn
+  value = module.rift[0].compute_manager_arn
 }
 output "compute_instance_profile_arn" {
-  value = module.rift.compute_instance_profile_arn
+  value = module.rift[0].compute_instance_profile_arn
 }
 output "compute_arn" {
-  value = module.rift.compute_arn
+  value = module.rift[0].compute_arn
 }
 output "vm_workload_subnet_ids" {
-  value = module.rift.vm_workload_subnet_ids
+  value = module.rift[0].vm_workload_subnet_ids
 }
 output "anyscale_docker_target_repo" {
-  value = module.rift.anyscale_docker_target_repo
+  value = module.rift[0].anyscale_docker_target_repo
 }
 output "nat_gateway_public_ips" {
-  value = module.rift.nat_gateway_public_ips
+  value = module.rift[0].nat_gateway_public_ips
 }
 output "rift_compute_security_group_id" {
-  value = module.rift.rift_compute_security_group_id
+  value = module.rift[0].rift_compute_security_group_id
 }


### PR DESCRIPTION
Updating `rift_sample` configuration outputs and syntax.

* Correct s3 logs destination to be ARN rather than just path.
* Correct `outputs` to reference `module.rift[0]` correctly.
