### PR TITLE
Allow ec2:DescribeInstanceTypes for Rift compute manager to better handle non-default instance types

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -59,6 +59,7 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     actions = [
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeNetworkInterfaces",
       "ec2:CreateTags",
       "ec2:DeleteTags"


### PR DESCRIPTION
This change allows compute manager role to retrieve information about EC2 instance types. This permission is necessary for the orchestrator to make informed decisions about instance selection and additional AMI/Docker configuration requirements.

Related orchestrator PR: https://github.com/tecton-ai/tecton/pull/25721