### PR TITLE
Set use_rift_cross_account_policy to true for dataplane rift sample.

### DIFF
--- a/rift_sample/infrastructure.tf
+++ b/rift_sample/infrastructure.tf
@@ -48,6 +48,7 @@ module "tecton" {
   s3_read_write_principals          = [format("arn:aws:iam::%s:root", local.tecton_control_plane_account_id)]
   use_rift_compute_on_control_plane = !local.enable_rift_on_data_plane
   use_spark_compute                 = false # Set to true if also enable Spark compute
+  use_rift_cross_account_policy     = true
 }
 
 module "rift" {


### PR DESCRIPTION
`use_rift_cross_account_policy` on `deployment` module is necessary for both control-plane and data-plane rift configurations (both rely on this role) -- updating `rift_sample` to set this property to true.