### PR TITLE
Add ListTagsOfResource permission to Dynamo policies

### DIFF
--- a/templates/ca_policy.json
+++ b/templates/ca_policy.json
@@ -18,6 +18,7 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
+                "dynamodb:ListTagsOfResource",
                 "dynamodb:UpdateTable",
                 "dynamodb:UpdateTimeToLive",
                 "dynamodb:DescribeTimeToLive"

--- a/templates/rift_ca_policy.json
+++ b/templates/rift_ca_policy.json
@@ -18,6 +18,7 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
+                "dynamodb:ListTagsOfResource",
                 "dynamodb:UpdateTable",
                 "dynamodb:UpdateTimeToLive",
                 "dynamodb:DescribeTimeToLive"

--- a/templates/satellite_ca_policy.json
+++ b/templates/satellite_ca_policy.json
@@ -18,6 +18,7 @@
                 "dynamodb:PutItem",
                 "dynamodb:Query",
                 "dynamodb:TagResource",
+                "dynamodb:ListTagsOfResource",
                 "dynamodb:UpdateTable",
                 "dynamodb:UpdateTimeToLive",
                 "dynamodb:DescribeTimeToLive"


### PR DESCRIPTION
This permission will allow Tecton to call ListTagsOfResources in order to determine which tags already exist on a table, to avoid unnecessary tagging operations (which have a low rate limit of 5 QPS across the account).