### PR TITLE
Add control-plane root principal to assume-role policy for rift-compute-manager.

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "rift_compute_manager" {
         Action = ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"]
         Effect = "Allow"
         Principal = {
-          AWS = var.rift_compute_manager_assuming_role_arns
+          AWS = "arn:aws:iam::${var.control_plane_account_id}:root"
         }
       }
     ]

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "rift_compute_manager" {
         Action = ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"]
         Effect = "Allow"
         Principal = {
-          AWS = concat([var.rift_compute_manager_assuming_role_arns], ["arn:aws:iam::${var.control_plane_account_id}:root"])
+          AWS = concat(var.rift_compute_manager_assuming_role_arns, ["arn:aws:iam::${var.control_plane_account_id}:root"])
         }
       }
     ]

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "rift_compute_manager" {
         Action = ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"]
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${var.control_plane_account_id}:root"
+          AWS = concat([var.rift_compute_manager_assuming_role_arns], ["arn:aws:iam::${var.control_plane_account_id}:root"])
         }
       }
     ]


### PR DESCRIPTION
In order to streamline cluster creation process, adding a trust relationship here to allow the root-principal from the Control-plane account to assume-role to `rift-compute-manager` role in dataplane. This will allow customers to spin up both the generic data-plane resources and rift-specific resources at the same time in between steps 1 and 2 of our cluster-creation, rather than requiring Rift added as a third step. (The reason it needs a third step now is that the control-plane 'worker-node' role is not created until the full control-plane is spun up, and we can't place a non-existent role in trust policy)

This mirrors  a similar setup for the cross-account role in standard `deployment` module for dataplane here: https://github.com/tecton-ai/tecton-terraform-setup/blob/master/deployment/roles.tf#L45.


Tested change with TF plan on internal cluster:
```
  # module.tecton-saas.module.rift[0].aws_iam_role.rift_compute_manager will be updated in-place
  ~ resource "aws_iam_role" "rift_compute_manager" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ AWS = [
                                "arn:aws:iam::<acct_id>:role/tecton-dev-zeus-worker-node",
                              + "arn:aws:iam::<acct_id>:root",
                            ]
                        }
                        # (2 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "ray-cluster-manager"
        name                  = "ray-cluster-manager"
        tags                  = {}
        # (9 unchanged attributes hidden)
    }
```