### PR TITLE
Remove redundant providers block from `privatelink/cross_vpc` module

### DIFF
--- a/privatelink/cross_vpc/README.md
+++ b/privatelink/cross_vpc/README.md
@@ -27,6 +27,9 @@ is tracked.
 ```hcl
 module "privatelink-cross-vpc" {
   source = "github.com/tecton-ai-ext/tecton-terraform-setup//privatelink/cross_vpc"
+  providers = {
+    aws = aws
+  }
 
   dns_name = "<deployment_name>.tecton.ai"
   vpc_endpoint_service_name = "<vpc_endpoint_service_name>"

--- a/privatelink/cross_vpc/versions.tf
+++ b/privatelink/cross_vpc/versions.tf
@@ -7,5 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {}


### PR DESCRIPTION
The `provider "aws" {}` block is not necessary anymore: ` Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.`

Tested by invoking this module from a control-plane tecton TF state + passing in `aws` provider as input, plan worked as expected.

```
module "privatelink" {
  providers = {
    aws = aws
  }
  source = "git::https://github.com/tecton-ai/tecton-terraform-setup.git//privatelink/cross_vpc?ref=no-providers-pvtlink-module"
  vpc_id                           = module.tecton-saas.kubernetes.vpc_id
  vpc_endpoint_service_name        = "com.amazonaws.vpce..."
  dns_name                         = "..."
  vpc_endpoint_subnet_ids          = module.tecton-saas.kubernetes.cluster_subnet_ids
  vpc_endpoint_security_group_name = "..."
  enable_vpc_endpoint_private_dns  = true
}
```