### PR TITLE
2 rift_compute VPC/privatelink fixes: Subnet ID, Private DNS

### DIFF
--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -29,7 +29,6 @@ module "public_private_subnet_cidrs" {
 resource "aws_vpc" "rift" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = (var.tecton_vpce_service_name != null)
-  enable_dns_support   = (var.tecton_vpce_service_name != null)
 }
 
 resource "aws_subnet" "private" {

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -27,7 +27,9 @@ module "public_private_subnet_cidrs" {
 }
 
 resource "aws_vpc" "rift" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
 }
 
 resource "aws_subnet" "private" {

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -28,8 +28,8 @@ module "public_private_subnet_cidrs" {
 
 resource "aws_vpc" "rift" {
   cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  enable_dns_hostnames = (var.tecton_vpce_service_name != null)
+  enable_dns_support   = (var.tecton_vpce_service_name != null)
 }
 
 resource "aws_subnet" "private" {

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -141,7 +141,7 @@ resource "aws_vpc_endpoint" "tecton_privatelink" {
 resource "aws_vpc_endpoint_subnet_association" "tecton_privatelink" {
   for_each        = var.tecton_vpce_service_name != null ? aws_subnet.private : {}
   vpc_endpoint_id = aws_vpc_endpoint.tecton_privatelink[0].id
-  subnet_id       = each.value
+  subnet_id       = each.value.id
 }
 
 


### PR DESCRIPTION
2 errors happen on terraform plan/apply for users of `rift_compute` who provide a VPC endpoint-service name input (privatelink).

1. Subnet ID reference
```sh
╷
│ Error: Incorrect attribute value type
│ 
│   on .terraform/modules/tecton-saas.rift/rift_compute/vpc.tf line 144, in resource "aws_vpc_endpoint_subnet_association" "tecton_privatelink":
│  144:   subnet_id       = each.value
│     ├────────────────
│     │ each.value is object with 23 attributes
│ 
│ Inappropriate value for attribute "subnet_id": string required.
```

`each.value` here is the subnet resource itself -- we need specifically the `id`.


2.  Private DNS without enabling it on VPC.
```sh
 InvalidParameter: Enabling private DNS requires both enableDnsSupport and enableDnsHostnames VPC attributes set to true for 
│   with module.tecton-saas.module.rift[0].aws_vpc_endpoint.tecton_privatelink[0],
│   on .terraform/modules/tecton-saas.rift/rift_compute/vpc.tf line 131, in resource "aws_vpc_endpoint" "tecton_privatelink":
│  131: resource "aws_vpc_endpoint" "tecton_privatelink" {
```
For private DNS on the vpc endpoint to work, the property `enable_dns_hostnames` must be set to true on the rift VPC.