### PR TITLE
Remove custom model flag

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -296,7 +296,7 @@ resource "aws_iam_policy" "offline_store_access" {
           format("%s/%s", var.offline_store_bucket_arn, var.offline_store_key_prefix),
           format("%s/%s*", var.offline_store_bucket_arn, var.offline_store_key_prefix),
           format("%s/%s", var.offline_store_bucket_arn, "tecton-model-artifacts"),
-          format("%s/%s*", var.offline_store_bucket_arn, "tecton-model-artifacts"),
+          format("%s/%s*", var.offline_store_bucket_arn, "tecton-model-artifacts")
         ])
       },
       {
@@ -415,3 +415,4 @@ resource "aws_iam_role_policy_attachment" "rift_compute_internal_policies" {
   role       = aws_iam_role.rift_compute.name
   policy_arn = aws_iam_policy.rift_compute_internal.arn
 }
+# ----------------

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -295,8 +295,8 @@ resource "aws_iam_policy" "offline_store_access" {
         Resource = compact([
           format("%s/%s", var.offline_store_bucket_arn, var.offline_store_key_prefix),
           format("%s/%s*", var.offline_store_bucket_arn, var.offline_store_key_prefix),
-          var.enable_custom_model ? format("%s/%s", var.offline_store_bucket_arn, "tecton-model-artifacts") : null,
-          var.enable_custom_model ? format("%s/%s*", var.offline_store_bucket_arn, "tecton-model-artifacts") : null
+          format("%s/%s", var.offline_store_bucket_arn, "tecton-model-artifacts"),
+          format("%s/%s*", var.offline_store_bucket_arn, "tecton-model-artifacts"),
         ])
       },
       {
@@ -415,4 +415,3 @@ resource "aws_iam_role_policy_attachment" "rift_compute_internal_policies" {
   role       = aws_iam_role.rift_compute.name
   policy_arn = aws_iam_policy.rift_compute_internal.arn
 }
-# ----------------

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -53,12 +53,6 @@ variable "is_internal_workload" {
   description = "Flag to indicate if the workload is internal to Tecton. Set it to true if for dev and demo clusters."
 }
 
-variable "enable_custom_model" {
-  type        = bool
-  default     = false
-  description = "If should grant worker node access to read model artifacts from s3. Still WIP and by default it doesn't."
-}
-
 variable "additional_rift_compute_policy_statements" {
   type        = list(any)
   description = "Additional IAM policy statements to attach to the rift_compute role"


### PR DESCRIPTION
The flag was used to gate if we should grant permission to m13n worker to access model storage dir. Remove this flag in tf because
1. the dev is completed, and feature is in private review
2. there is cluster level flag to control this feature, so we don't need this flag in tf level any more.