### PR TITLE
feat: fine-grained S3 permissions

### DIFF
--- a/templates/ca_policy.json
+++ b/templates/ca_policy.json
@@ -45,15 +45,42 @@
             ]
         },
         {
-            "Sid": "S3Object",
+            "Sid": "S3GetObject",
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject",
-                "s3:DeleteObject",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/realtime-logs/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*",
+            ]
+        },
+        {
+            "Sid": "S3DeleteObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*"
+            ]
+        },
+        {
+            "Sid": "S3PutObject",
+            "Effect": "Allow",
+            "Action": [
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/*"
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/logging/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/realtime-logs/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/tecton-billable-usage/*"
             ]
         },
         {

--- a/templates/ca_policy.json
+++ b/templates/ca_policy.json
@@ -55,7 +55,7 @@
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/realtime-logs/*",
-                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*"
             ]
         },
         {

--- a/templates/ca_policy.json
+++ b/templates/ca_policy.json
@@ -76,6 +76,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/logging/*",

--- a/templates/rift_ca_policy.json
+++ b/templates/rift_ca_policy.json
@@ -45,15 +45,45 @@
             ]
         },
         {
-            "Sid": "S3Object",
+            "Sid": "S3GetObject",
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject",
-                "s3:DeleteObject",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/realtime-logs/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/rift-logs/*"
+            ]
+        },
+        {
+            "Sid": "S3DeleteObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/rift-logs/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/streaming-checkpoints/*"
+            ]
+        },
+        {
+            "Sid": "S3PutObject",
+            "Effect": "Allow",
+            "Action": [
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/*"
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/logging/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/realtime-logs/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/tecton-billable-usage/*",
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/rift-logs/*"
             ]
         },
         {

--- a/templates/rift_ca_policy.json
+++ b/templates/rift_ca_policy.json
@@ -78,6 +78,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/offline-store/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/intermediate/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/internal/*",
                 "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/logging/*",


### PR DESCRIPTION
### TL;DR
Split S3 bucket permissions into separate, granular policies for GetObject, DeleteObject, and PutObject operations.

### What changed?
- Replaced the broad `S3Object` policy with three specific policies:
  - `S3GetObject`: Controls read access to specific S3 paths
  - `S3DeleteObject`: Limits delete permissions to offline-store and streaming-checkpoints
  - `S3PutObject`: Restricts write access to specific directories
- Added rift-logs specific permissions in the rift policy template

### How to test?
1. Deploy the updated policies to a few internal environment, spanning across different compute types.
2. Verify that:
   - Read operations work for all specified paths
   - Delete operations only work for offline-store and streaming-checkpoints
   - Write operations are successful only for the designated directories
   - Rift-specific operations function as expected

### Why make this change?
Implements the principle of least privilege by providing more granular S3 bucket permissions, reducing potential security risks by limiting access to only what's necessary for each operation type.