### PR TITLE
Add variables for VPC cidr range and custom ingress rules on privatelink endpoint in rift-compute 

### DIFF
--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -77,3 +77,32 @@ variable "additional_allowed_egress_domains" {
   description = "Additional domains to allow egress to (if using network firewall)"
 }
 
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC (e.g. 10.0.0.0/16)"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "tecton_privatelink_ingress_rules" {
+  description = "List of custom ingress rules for the Tecton PrivateLink endpoint security group with CIDR, ports, and protocol. If empty, a default 'allow all' rule will be created."
+  type = list(object({
+    cidr        = string
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    description = string
+  }))
+  default = []
+}
+
+variable "tecton_privatelink_egress_rules" {
+  description = "List of egress rules for the Tecton PrivateLink security group. If empty, all traffic is allowed."
+  type = list(object({
+    cidr        = string
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    description = string
+  }))
+  default = []
+}

--- a/samples/dataplane_rift/README.md
+++ b/samples/dataplane_rift/README.md
@@ -24,3 +24,5 @@ Finally, there are a set of `outputs` from the modules that will need to be shar
 * `use_network_firewall` -- this is an optional (default `false`) parameter for the Rift compute VPC, to enable an AWS network firewall with egress restrictions/drop rules based on a fixed list of allowed domains.
   * The list of allowed domains can be extended with `additional_allowed_egress_domains` variable (list).
 * `tecton_vpce_service_name` -- this is an optional parameter for the Rift module that creates a vpc-endpoint within the rift VPC for access to the tecton control-plane. This is only applicable if your Tecton deployment has been set up with PrivateLink.
+* `tecton_privatelink_ingress_rules` -- If you use PrivateLink and set `tecton_vpce_service_name`, you can control the ingress rules on the VPC endpoint that will be created for compute jobs to access Tecton's control plane. 
+* `tecton_privatelink_egress_rules` -- Similarly, you can control the _egress_ rules on the VPC endpoint.

--- a/samples/dataplane_rift/infrastructure.tf
+++ b/samples/dataplane_rift/infrastructure.tf
@@ -56,6 +56,27 @@ module "rift" {
 
   # OPTIONAL
   # tecton_vpce_service_name                = local.tecton_vpce_service_name
+  # Tecton PrivateLink Security Group Rules (apply to VPC endpoint to access Tecton ctrl plane)
+  # tecton_privatelink_ingress_rules = [
+  #   {
+  #     cidr        = "10.0.0.0/24"
+  #     from_port   = 0
+  #     to_port     = 65535
+  #     protocol    = "-1"
+  #     description = "Allow all ingress from <Internal> VPC"
+  #   }
+  # ]
+  # Tecton PrivateLink Security Group Egress Rules (apply to VPC endpoint to access Tecton ctrl plane)
+  # tecton_privatelink_egress_rules = [
+  #   {
+  #     cidr        = "10.0.0.0/24"
+  #     from_port   = 0
+  #     to_port     = 65535
+  #     protocol    = "-1"
+  #     description = "Allow all egress to <Internal> VPC"
+  #   }
+  # ]
+  #
   # Egress from rift compute will be open to internet by default.
   # To restrict egress based on known list of domains (found in rift_compute/network_firewall.tf), set the following:
   # use_network_firewall = true


### PR DESCRIPTION
Adding a `vpc_cidr` and a `tecton_privatelink_ingress_rules` variable to allow specifying CIDR range and custom ingress rules for the tecton privatelink VPC endpoint within the rift VPC.

Tested with TF plan on `rift-compute-options` branch of tecton repo (`tecton-dev-ops-dataplane`).