### PR TITLE
Remove use of remote module and add copy of cidr module.

### DIFF
--- a/remote-modules/subnets-cidr/README.md
+++ b/remote-modules/subnets-cidr/README.md
@@ -1,0 +1,7 @@
+# CIDR Subnets Module
+
+This is a local copy of the [hashicorp/subnets/cidr](https://registry.terraform.io/modules/hashicorp/subnets/cidr/) Terraform module, version 1.0.0.
+
+## Original Source
+- Terraform Registry: https://registry.terraform.io/modules/hashicorp/subnets/cidr/
+- GitHub Repository: https://github.com/hashicorp/terraform-cidr-subnets

--- a/remote-modules/subnets-cidr/main.tf
+++ b/remote-modules/subnets-cidr/main.tf
@@ -1,0 +1,9 @@
+locals {
+  addrs_by_idx  = cidrsubnets(var.base_cidr_block, var.networks[*].new_bits...)
+  addrs_by_name = { for i, n in var.networks : n.name => local.addrs_by_idx[i] if n.name != null }
+  network_objs = [for i, n in var.networks : {
+    name       = n.name
+    new_bits   = n.new_bits
+    cidr_block = n.name != null ? local.addrs_by_idx[i] : tostring(null)
+  }]
+}

--- a/remote-modules/subnets-cidr/outputs.tf
+++ b/remote-modules/subnets-cidr/outputs.tf
@@ -1,0 +1,14 @@
+output "network_cidr_blocks" {
+  value       = tomap(local.addrs_by_name)
+  description = "A map from network names to allocated address prefixes in CIDR notation."
+}
+
+output "networks" {
+  value       = tolist(local.network_objs)
+  description = "A list of objects corresponding to each of the objects in the input variable 'networks', each extended with a new attribute 'cidr_block' giving the network's allocated address prefix."
+}
+
+output "base_cidr_block" {
+  value       = var.base_cidr_block
+  description = "Echoes back the base_cidr_block input variable value, for convenience if passing the result of this module elsewhere as an object."
+}

--- a/remote-modules/subnets-cidr/variables.tf
+++ b/remote-modules/subnets-cidr/variables.tf
@@ -1,0 +1,12 @@
+variable "base_cidr_block" {
+  type        = string
+  description = "A network address prefix in CIDR notation that all of the requested subnetwork prefixes will be allocated within."
+}
+
+variable "networks" {
+  type = list(object({
+    name     = string
+    new_bits = number
+  }))
+  description = "A list of objects describing requested subnetwork prefixes. new_bits is the number of additional network prefix bits to add, in addition to the existing prefix on base_cidr_block."
+}

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -87,8 +87,7 @@ resource "aws_networkfirewall_rule_group" "rift_compute_egress_allowed_domains" 
 }
 
 module "firewall_subnet_cidrs" {
-  source          = "hashicorp/subnets/cidr"
-  version         = "1.0.0"
+  source          = "../remote-modules/subnets-cidr"
   base_cidr_block = "10.0.24.0/22"  # Start from the next available /22 block
   networks = [for i, az in var.subnet_azs :
     {

--- a/rift_compute/vpc.tf
+++ b/rift_compute/vpc.tf
@@ -4,8 +4,7 @@ locals {
 }
 
 module "az_subnet_cidrs" {
-  source          = "hashicorp/subnets/cidr" # https://registry.terraform.io/modules/hashicorp/subnets/cidr/
-  version         = "1.0.0"
+  source          = "../remote-modules/subnets-cidr"
   base_cidr_block = local.vpc_cidr
   networks = [for az in var.subnet_azs :
     {
@@ -17,8 +16,7 @@ module "az_subnet_cidrs" {
 
 module "public_private_subnet_cidrs" {
   for_each        = module.az_subnet_cidrs.network_cidr_blocks
-  source          = "hashicorp/subnets/cidr" # https://registry.terraform.io/modules/hashicorp/subnets/cidr/
-  version         = "1.0.0"
+  source          = "../remote-modules/subnets-cidr"
   base_cidr_block = each.value
   networks = [
     { name = format("public"), new_bits = 1 },


### PR DESCRIPTION
Removing the use of remote module and copying in the hashicorp/subnets/cidr module source here for local use.

Tested on `tecton-dev-ops-dataplane`:
```diff
 module "rift" {
-  source                                  = "git::https://github.com/tecton-ai/tecton-terraform-setup.git//rift_compute"
+  source                                  = "git::https://github.com/tecton-ai/tecton-terraform-setup.git//rift_compute?ref=remote-cidr-module"
```

TF plan output:
```bash
No changes. Your infrastructure matches the configuration.
```