### PR TITLE
Narrow down ECR permissions for cross account image uploads

### DIFF
--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -28,7 +28,11 @@ data "aws_iam_policy_document" "cross_account_ecr" {
     }
 
     actions = [
-      "ecr:*" # TODO @jwheeler scope down
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
     ]
   }
 }


### PR DESCRIPTION
https://linear.app/tecton/issue/CI-119/narrow-down-ecr-permissions-run-custom-env-tests-on-vm-rift

TLDR: reducing Rift ECR permissions granted to the Tecton control plane down to the minimum required to push images.