### PR TITLE
Update egress domain allowlist (rift_compute network firewall)

### DIFF
--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -14,11 +14,6 @@ locals {
     ".ubuntu.com",
     "sts.amazonaws.com",
     ".amazonaws.com",
-    # Crowdstrike
-    "crowdstrike.github.io",
-    ".crowdstrike.com",
-    ".cloudsink.net",
-    ".githubusercontent.com",
   ]
 
 }

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -11,7 +11,8 @@ locals {
     "extensions.duckdb.org",
     "api.snapcraft.io",
     "esm.ubuntu.com",
-    ".ubuntu.com",
+    "security.ubuntu.com",
+    "archive.ubuntu.com",
     "sts.amazonaws.com",
     ".amazonaws.com",
   ]

--- a/rift_compute/network_firewall.tf
+++ b/rift_compute/network_firewall.tf
@@ -3,21 +3,22 @@
 
 locals {
   default_allowed_egress_domains = [
-    ".tecton.ai",             # tecton control plane for this cluster
+    "${var.cluster_name}.tecton.ai",  # tecton control plane for this cluster
     "tecton.chronosphere.io", # Metrics
     "packages.fluentbit.io",
-    ".ecr.aws",
-    ".amazonaws.com",
-    ".aws.amazon.com",
-    ".ubuntu.com",
-    ".canonical.com",
+    # Extract full domain from ECR repo URL (e.g., 123456789012.dkr.ecr.us-west-2.amazonaws.com)
+    regex("^(https?://)?([^/]+).*", aws_ecr_repository.rift_env.repository_url)[1],
+    "extensions.duckdb.org",
     "api.snapcraft.io",
-    ".duckdb.org",
+    "esm.ubuntu.com",
+    ".ubuntu.com",
+    "sts.amazonaws.com",
+    ".amazonaws.com",
     # Crowdstrike
+    "crowdstrike.github.io",
     ".crowdstrike.com",
     ".cloudsink.net",
     ".githubusercontent.com",
-    "crowdstrike.github.io",
   ]
 
 }


### PR DESCRIPTION
Make some wildcard domains more specific in default allowlist for the network firewall option in rift_compute module.

Reduced to a minimal set for jobs to work (tested in tecton-dev-ops-dataplane).