### PR TITLE
allow to fetch vcpu quota for rift jobs

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -151,6 +151,16 @@ data "aws_iam_policy_document" "manage_rift_compute" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "servicequotas:GetServiceQuota"
+    ]
+    resources = [
+      "arn:aws:servicequotas:*:${local.account_id}:ec2/L-1216C47A"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "manage_rift_compute" {


### PR DESCRIPTION
It is possible that many Rift VM jobs get launched that compete for VCPUs within a customer's account. We want to limit Rift VM job capacity by vCPUs. This PR allows rift cluster managed role to fetch the vcpu service quota 