### PR TITLE
[vpc] Add support for rift compute on VPC clusters

### DIFF
--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -113,6 +113,43 @@ variable "data_validation_on_fargate_enabled" {
   type        = bool
 }
 
+variable "rift_compute_manager_arn" {
+  type        = string
+  description = "ARN of the Rift compute manager role that the EKS worker role needs to assume"
+  default     = null
+}
+
+variable "enable_rift" {
+  default     = false
+  type        = bool
+  description = "Whether to enable Rift integration. When true, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
+}
+
+variable "rift_ecr_repository_arn" {
+  type        = string
+  description = "ARN of the Rift ECR repository"
+  default     = null
+}
+
+variable "offline_store_bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket containing the offline store data"
+  default     = ""
+}
+
+variable "offline_store_key_prefix" {
+  type        = string
+  description = "Key prefix for offline store data within the S3 bucket"
+  default     = "offline-store/"
+}
+
+variable "offline_store_cmk_arns" {
+  type        = list(string)
+  description = "List of ARNs for KMS CMKs used to encrypt offline store data"
+  default     = []
+}
+
+
 module "eks_subnets" {
   providers = {
     aws = aws
@@ -195,6 +232,12 @@ module "roles" {
   data_validation_on_fargate_enabled = var.data_validation_on_fargate_enabled
   vpc_id                             = module.eks_subnets.vpc_id
   enable_feature_server_as_compute_instance_groups = var.enable_feature_server_as_compute_instance_groups
+  rift_compute_manager_arn           = var.rift_compute_manager_arn
+  enable_rift                        = var.enable_rift
+  rift_ecr_repository_arn            = var.rift_ecr_repository_arn
+  offline_store_bucket_arn           = var.offline_store_bucket_arn
+  offline_store_key_prefix           = var.offline_store_key_prefix
+  offline_store_cmk_arns             = var.offline_store_cmk_arns
 }
 
 module "notebook_cluster" {

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -113,16 +113,16 @@ variable "data_validation_on_fargate_enabled" {
   type        = bool
 }
 
+variable "enable_rift" {
+  default     = false
+  type        = bool
+  description = "Whether to enable Rift integration. When true, rift_compute_manager_arn, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
+}
+
 variable "rift_compute_manager_arn" {
   type        = string
   description = "ARN of the Rift compute manager role that the EKS worker role needs to assume"
   default     = null
-}
-
-variable "enable_rift" {
-  default     = false
-  type        = bool
-  description = "Whether to enable Rift integration. When true, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
 }
 
 variable "rift_ecr_repository_arn" {

--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -134,7 +134,7 @@ variable "rift_ecr_repository_arn" {
 variable "offline_store_bucket_arn" {
   type        = string
   description = "ARN of the S3 bucket containing the offline store data"
-  default     = ""
+  default     = null
 }
 
 variable "offline_store_key_prefix" {

--- a/emr_sample/outputs.tf
+++ b/emr_sample/outputs.tf
@@ -59,3 +59,7 @@ output "s3_replication_policy_name" {
 output "s3_batch_replication_policy_name" {
   value = length(var.satellite_regions) > 0 ? module.roles[0].s3_batch_replication_policy_name : ""
 }
+
+output "offline_store_reader_role_arn" {
+  value = var.enable_rift ? module.roles[0].offline_store_reader_role_arn : null
+}

--- a/roles/outputs.tf
+++ b/roles/outputs.tf
@@ -34,6 +34,10 @@ output "offline_ingest_role_arn" {
   value = aws_iam_role.online_ingest_role[0].arn
 }
 
+output "offline_store_reader_role_arn" {
+  value = local.enable_offline_store_reader ? aws_iam_role.offline_store_reader[0].arn : null
+}
+
 #########################################
 ################ Fargate ################
 #########################################

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -99,3 +99,39 @@ variable "vpc_id" {
   default = null
 }
 
+variable "rift_compute_manager_arn" {
+  type        = string
+  description = "ARN of the Rift compute manager role that the EKS worker role needs to assume"
+  default     = null
+}
+
+variable "enable_rift" {
+  default     = false
+  type        = bool
+  description = "Whether to enable Rift integration. When true, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
+}
+
+variable "rift_ecr_repository_arn" {
+  type        = string
+  description = "ARN of the Rift ECR repository"
+  default     = null
+}
+
+variable "offline_store_bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket containing the offline store data"
+  default     = ""
+}
+
+variable "offline_store_key_prefix" {
+  type        = string
+  description = "Key prefix for offline store data within the S3 bucket"
+  default     = "offline-store/"
+}
+
+variable "offline_store_cmk_arns" {
+  type        = list(string)
+  description = "List of ARNs for KMS CMKs used to encrypt offline store data"
+  default     = []
+}
+

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -120,7 +120,7 @@ variable "rift_ecr_repository_arn" {
 variable "offline_store_bucket_arn" {
   type        = string
   description = "ARN of the S3 bucket containing the offline store data"
-  default     = ""
+  default     = null
 }
 
 variable "offline_store_key_prefix" {

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -99,16 +99,16 @@ variable "vpc_id" {
   default = null
 }
 
+variable "enable_rift" {
+  default     = false
+  type        = bool
+  description = "Whether to enable Rift integration. When true, rift_compute_manager_arn, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
+}
+
 variable "rift_compute_manager_arn" {
   type        = string
   description = "ARN of the Rift compute manager role that the EKS worker role needs to assume"
   default     = null
-}
-
-variable "enable_rift" {
-  default     = false
-  type        = bool
-  description = "Whether to enable Rift integration. When true, rift_ecr_repository_arn and offline_store_bucket_arn should be provided. Default: false."
 }
 
 variable "rift_ecr_repository_arn" {

--- a/templates/eks_policy_with_rift.json
+++ b/templates/eks_policy_with_rift.json
@@ -1,0 +1,165 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DynamoDB",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:CreateTable",
+                "dynamodb:DeleteItem",
+                "dynamodb:DeleteTable",
+                "dynamodb:DescribeImport",
+                "dynamodb:DescribeTable",
+                "dynamodb:GetItem",
+                "dynamodb:ImportTable",
+                "dynamodb:PutItem",
+                "dynamodb:Query",
+                "dynamodb:TagResource",
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:UpdateTable",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:DescribeTimeToLive"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/tecton-${DEPLOYMENT_NAME}*"
+            ]
+        },
+        {
+            "Sid": "DynamoDBGlobal",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:ListTables",
+                "dynamodb:DescribeLimits"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "S3Bucket",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}"
+            ]
+        },
+        {
+            "Sid": "S3Object",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-${DEPLOYMENT_NAME}/*"
+            ]
+        },
+        {
+            "Sid": "S3Logs",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": [
+		        "arn:aws:s3:::tecton-logs-aggregation/*"
+            ]
+        },
+        {
+            "Sid": "CreateServiceLinkedRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+            ]
+        },
+        {
+            "Sid": "CloudwatchLogging",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:*",
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:/aws-dynamodb/imports:log-stream:*",
+                  "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group::log-stream:*"
+            ]
+        },
+        {
+            "Sid": "RiftComputeManagerAssumeRole",
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole",
+                "sts:TagSession"
+            ],
+            "Resource": [
+                "${RIFT_COMPUTE_MANAGER_ARN}"
+            ]
+        },
+        {
+            "Sid": "RiftECRRepositoryAccess",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeImages",
+                "ecr:DescribeRepositories",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetLifecyclePolicy",
+                "ecr:GetLifecyclePolicyPreview",
+                "ecr:GetRepositoryPolicy",
+                "ecr:InitiateLayerUpload",
+                "ecr:ListImages",
+                "ecr:ListTagsForResource",
+                "ecr:PutImage",
+                "ecr:PutLifecyclePolicy",
+                "ecr:TagResource",
+                "ecr:UntagResource",
+                "ecr:UploadLayerPart"
+            ],
+            "Resource": [
+                "${RIFT_ECR_REPOSITORY_ARN}"
+            ]
+        },
+        {
+            "Sid": "RiftECRAuthorizationToken",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "RiftS3ReleasesAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-materialization-release/*"
+            ]
+        },
+        {
+            "Sid": "RiftS3ReleasesListBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::tecton-materialization-release"
+            ]
+        }
+    ]
+} 

--- a/templates/offline_store_reader_policy.json
+++ b/templates/offline_store_reader_policy.json
@@ -1,0 +1,31 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ObjectActions",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["${OFFLINE_STORE_BUCKET_ARN}/${OFFLINE_STORE_KEY_PREFIX}*"]
+    },
+    {
+      "Sid": "BucketActions",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["${OFFLINE_STORE_BUCKET_ARN}"],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["${OFFLINE_STORE_KEY_PREFIX}*"]
+        }
+      }
+    }
+    %{ if HAS_CMK }
+    ,
+    {
+      "Sid": "CMKs",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": ${OFFLINE_STORE_CMK_ARNS}
+    }
+    %{ endif }
+  ]
+} 


### PR DESCRIPTION
Changes to allow Rift compute to run on deployments set up with the `vpc` model:

Adding an `enable_rift` boolean variable to `roles` module as well as `emr_sample`. If enabled, a different policy file with additional policies for rift (`eks_policy_with_rift.json`) is used. In addition, an 'offline store reader role' is created that can be assumed by the EKS worker and has access to read offline store paths. The following variable inputs are needed with this flag:
* `rift_compute_manager_arn` -- EKS worker role will be allowed to AssumeRole into this role (created separately in `rift_compute` module and passed in as input).
* `rift_ecr_repository_arn` -- EKS worker will be allowed to push to this repo (created separately in `rift_compute` module and passed in as input).

There are also optional parameters:
* `offline_store_key_prefix`: For cases where the offline store does not have default `offline-store/` prefix.
* `offline_store_cmk_arns`: List of ARNs for KMS keys used to encrypt offline store data.