### PR TITLE
chore: add missing FSG permissions

### DIFF
--- a/templates/alb_policy.json
+++ b/templates/alb_policy.json
@@ -27,6 +27,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -160,6 +160,14 @@
             "Effect": "Allow",
             "Resource": "*",
             "Condition": {"StringEquals": {"aws:ResourceTag/tecton-owned": "true"}}
+        },
+        {
+            "Sid": "ManageSecurityGroupRuleDescriptionsIngress",
+            "Action": [
+                "ec2:UpdateSecurityGroupRuleDescriptionsIngress"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:ec2:*:${ACCOUNT_ID}:security-group/*"
         }
     ]
 }

--- a/templates/eks_asg_management.json
+++ b/templates/eks_asg_management.json
@@ -63,6 +63,7 @@
             "Sid": "ListenerRuleMgmt",
             "Effect": "Allow",
             "Action": [
+               "elasticloadbalancing:ModifyListener",
                "elasticloadbalancing:CreateRule",
                "elasticloadbalancing:AddTags",
                "elasticloadbalancing:DeleteRule"
@@ -131,7 +132,8 @@
             "Effect": "Allow",
             "Action": [
                 "ec2:CreateTags",
-                "ec2:RunInstances"
+                "ec2:RunInstances",
+                "ec2:UpdateSecurityGroupRuleDescriptionsIngress"
             ],
             "Resource": [
                 "arn:aws:ec2:*:${ACCOUNT_ID}:instance/*",

--- a/templates/eks_asg_management.json
+++ b/templates/eks_asg_management.json
@@ -132,8 +132,7 @@
             "Effect": "Allow",
             "Action": [
                 "ec2:CreateTags",
-                "ec2:RunInstances",
-                "ec2:UpdateSecurityGroupRuleDescriptionsIngress"
+                "ec2:RunInstances"
             ],
             "Resource": [
                 "arn:aws:ec2:*:${ACCOUNT_ID}:instance/*",

--- a/templates/fargate_eks_role.json
+++ b/templates/fargate_eks_role.json
@@ -26,6 +26,7 @@
         "Effect": "Allow",
         "Action": [
             "s3:GetObject",
+            "s3:GetObjectVersion",
             "s3:PutObject",
             "s3:DeleteObject"
         ],


### PR DESCRIPTION
## Description

Added two missing permissions required for launching feature server group.

## Test plan
1. Check out the feature branch from an internal cluster
2. Test `terraform apply` which previously failed due to the missing permissions
3. Expect the apply to pass