### PR TITLE
Fix permission for eks KMS encryption for VPC clusters

### DIFF
--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -174,7 +174,7 @@
                 "kms:ListKeys",
                 "kms:ListAliases"
             ],
-            "Sid": "EKSEncryption",
+            "Sid": "EKSEncryptionKeyCreation",
             "Effect": "Allow",
             "Resource":  "*"
         }

--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -170,8 +170,7 @@
         },
         {
             "Action": [
-                "kms:CreateKey",
-
+                "kms:CreateKey"
             ],
             "Sid": "EKSEncryption",
             "Effect": "Allow",

--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -154,7 +154,6 @@
         {
             "Action": [
                 "kms:EnableKeyRotation",
-                "kms:CreateKey",
                 "kms:DescribeKey",
                 "kms:GetKeyPolicy",
                 "kms:GetKeyRotationStatus",
@@ -168,6 +167,15 @@
             "Sid": "EKSEncryption",
             "Effect": "Allow",
             "Resource":  "arn:aws:kms:*:${ACCOUNT_ID}:key/*"
+        },
+        {
+            "Action": [
+                "kms:CreateKey",
+
+            ],
+            "Sid": "EKSEncryption",
+            "Effect": "Allow",
+            "Resource":  "*"
         }
     ]
 }

--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -170,7 +170,9 @@
         },
         {
             "Action": [
-                "kms:CreateKey"
+                "kms:CreateKey",
+                "kms:ListKeys",
+                "kms:ListAliases"
             ],
             "Sid": "EKSEncryption",
             "Effect": "Allow",


### PR DESCRIPTION
# What
* Adds needed permissions to be able to create KMS key for EKS secrets encryption

# Why
* Tecton requires extra IAM permissions to be able to create the needed KMS key for EKS secrets encryption