### PR TITLE
fix: eks permissions for VPC clusters

### DIFF
--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -83,7 +83,7 @@
                 "eks:AssociateEncryptionConfig"
             ],
             "Resource": [
-                "arn:aws:eks:*:${ACCOUNT_ID}:cluster/${DEPLOYMENT_NAME}*"
+                "arn:aws:eks:*:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*"
             ]
         },
         {
@@ -96,7 +96,7 @@
                 "eks:UpdateNodegroupVersion"
             ],
             "Resource": [
-                "arn:aws:eks:*:${ACCOUNT_ID}:nodegroup/${DEPLOYMENT_NAME}*"
+                "arn:aws:eks:*:${ACCOUNT_ID}:nodegroup/tecton-${DEPLOYMENT_NAME}*"
             ]
         },
         {

--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -5,6 +5,7 @@
             "Sid": "EksGlobal",
             "Effect": "Allow",
             "Action": [
+                "eks:CreateCluster",
                 "eks:ListClusters"
             ],
             "Resource": [
@@ -66,30 +67,36 @@
             }
         },
         {
-            "Sid": "Eks",
+            "Sid": "Cluster",
             "Effect": "Allow",
             "Action": [
-                "eks:CreateCluster",
                 "eks:CreateNodegroup",
-                "eks:DeleteNodegroup",
-                "eks:DescribeNodegroup",
                 "eks:ListNodegroups",
                 "eks:DescribeCluster",
-                "eks:ListClusters",
                 "eks:AccessKubernetesApi",
                 "eks:ListUpdates",
                 "eks:ListFargateProfiles",
                 "eks:UpdateClusterVersion",
-                "eks:UpdateNodegroupConfig",
-                "eks:UpdateNodegroupVersion",
                 "eks:UpdateClusterConfig",
                 "eks:DescribeUpdate",
                 "eks:DeleteCluster",
                 "eks:AssociateEncryptionConfig"
             ],
             "Resource": [
-                "arn:aws:eks:*:${ACCOUNT_ID}:cluster/tecton-${DEPLOYMENT_NAME}*",
-                "arn:aws:eks:*:${ACCOUNT_ID}:nodegroup/tecton-${DEPLOYMENT_NAME}*"
+                "arn:aws:eks:*:${ACCOUNT_ID}:cluster/${DEPLOYMENT_NAME}*"
+            ]
+        },
+        {
+            "Sid": "Nodegroup",
+            "Effect": "Allow",
+            "Action": [
+                "eks:DeleteNodegroup",
+                "eks:DescribeNodegroup",
+                "eks:UpdateNodegroupConfig",
+                "eks:UpdateNodegroupVersion"
+            ],
+            "Resource": [
+                "arn:aws:eks:*:${ACCOUNT_ID}:nodegroup/${DEPLOYMENT_NAME}*"
             ]
         },
         {


### PR DESCRIPTION
## Why
EKS IAM permissions for VPC devops role does not follow minimum privilege principle. In addition, some permissions (e.g. 'eks:ListClusters') don't support resource scoping and should scope to resource `*`

## What
1. Separate the permissions for EKS cluster and nodegroup
2. Move `eks:ListClusters` permission to `EksGlobal` policy

## Test plan

Test in an internal cluster