### PR TITLE
Add variable for additional intermediary role to rift_compute.

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -200,7 +200,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
   name = "tecton-rift-dynamodb-access"
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
         Effect = "Allow"
         Action = [
@@ -226,7 +226,14 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
         # Used for assume into cross-account-intermediary role when Rift is in control plane account.
         Resource = ["arn:aws:iam::${local.account_id}:role/${var.cluster_name}-cross-account-intermediate"]
       }
-    ]
+    ],
+    length(var.additional_rift_compute_intermediary_role) > 0 ? [{
+      Effect = "Allow"
+      Action = [
+        "sts:AssumeRole"
+      ]
+      Resource = var.additional_rift_compute_intermediary_role
+    }] : [])
   })
 }
 

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -106,3 +106,9 @@ variable "tecton_privatelink_egress_rules" {
   }))
   default = []
 }
+
+variable "additional_rift_compute_intermediary_role" {
+  type        = list(string)
+  description = "Additional IAM role ARN that the rift-compute role can assume. If provided, this will be added to the list of roles that can be assumed via the dynamodb access policy."
+  default     = []
+}


### PR DESCRIPTION
Adding a variable here for additional 'intermediate' role that the rift-compute role can AssumeRole to (in addition to the control-plane intermediate role). This will be used for backwards-compatibility for Anyscale --> _control-plane_ VM rift migrations so that the rift compute role in control plane can assume the existing ('saas-master') intermediate role that was used in anyscale setup.