### PR TITLE
Add optional AWS secret manager access for the Rift compute role

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -231,6 +231,7 @@ resource "aws_iam_policy" "rift_dynamodb_access" {
 }
 
 resource "aws_iam_policy" "rift_legacy_secrets_manager_access" {
+  count = var.enable_rift_legacy_secret_manager_access ? 1 : 0
   name = "tecton-rift-legacy-secrets-manager-access"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -419,19 +420,25 @@ resource "aws_iam_policy" "additional_rift_compute_policy" {
 }
 
 locals {
-  rift_compute_policies = {
+  # Base set of policies to attach to the rift_compute role
+  rift_compute_policies_base = {
     rift_compute_logs    = aws_iam_policy.rift_compute_logs,
     offline_store_access = aws_iam_policy.offline_store_access,
     dynamo_db_access     = aws_iam_policy.rift_dynamodb_access,
     ecr_readonly         = aws_iam_policy.rift_ecr_readonly
   }
+  # Include legacy Secrets Manager access policy when enabled
+  rift_compute_policies = merge(
+    local.rift_compute_policies_base,
+    var.enable_rift_legacy_secret_manager_access ? {
+      rift_legacy_secrets_manager_access = aws_iam_policy.rift_legacy_secrets_manager_access[0]
+    } : {}
+  )
 }
 
 resource "aws_iam_role_policy_attachment" "rift_compute_policies" {
-  for_each   = !var.enable_rift_legacy_secret_manager_access ? local.rift_compute_policies:
-  merge(local.rift_compute_policies, {
-    rift_legacy_secrets_manager_access       = aws_iam_policy.rift_legacy_secrets_manager_access
-  })
+  # Attach each policy in the computed set
+  for_each   = local.rift_compute_policies
   role       = aws_iam_role.rift_compute.name
   policy_arn = each.value.arn
 }

--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -239,8 +239,7 @@ resource "aws_iam_policy" "rift_legacy_secrets_manager_access" {
       {
         Effect = "Allow"
         Action = [
-            "secretsmanager:GetSecretValue",
-            "secretsmanager:DescribeSecret"
+            "secretsmanager:*"
         ]
         Resource = [
           "arn:aws:secretsmanager:*:${local.account_id}:secret:tecton-*",

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -56,7 +56,7 @@ variable "is_internal_workload" {
 variable "enable_rift_legacy_secret_manager_access" {
   type        = bool
   default     = false
-  description = "Flag to indicate if Rift jobs access secret manager directly instead of Tecton secrets. Set it to true if for Anyscale clusters."
+  description = "Flag to indicate if Rift jobs access secret manager directly instead of Tecton secrets. Set it to true for some Anyscale clusters."
 }
 
 variable "additional_rift_compute_policy_statements" {

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -56,7 +56,7 @@ variable "is_internal_workload" {
 variable "enable_rift_legacy_secret_manager_access" {
   type        = bool
   default     = false
-  description = "Flag to indicate if Rift jobs access secret manager directly instead of Tecton secrets. Set it to true for some Anyscale clusters."
+  description = "Flag to indicate if supporting legacy secret management or not. Directly accessing secret manager from Rift jobs is no longer supported. Tecton Secrets should be used instead"
 }
 
 variable "additional_rift_compute_policy_statements" {

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -53,6 +53,12 @@ variable "is_internal_workload" {
   description = "Flag to indicate if the workload is internal to Tecton. Set it to true if for dev and demo clusters."
 }
 
+variable "enable_rift_legacy_secret_manager_access" {
+  type        = bool
+  default     = false
+  description = "Flag to indicate if Rift jobs access secret manager directly instead of Tecton secrets. Set it to true if for Anyscale clusters."
+}
+
 variable "additional_rift_compute_policy_statements" {
   type        = list(any)
   description = "Additional IAM policy statements to attach to the rift_compute role"


### PR DESCRIPTION
Adding optional AWS secret manager access for the Rift compute role to support legacy secret management for some customers