### PR TITLE
Fix module reference in vpc databricks_sample.

### DIFF
--- a/databricks_sample/infrastructure.tf
+++ b/databricks_sample/infrastructure.tf
@@ -122,7 +122,7 @@ module "roles" {
   elasticache_enabled                = var.elasticache_enabled
   fargate_enabled                    = var.fargate_enabled
   data_validation_on_fargate_enabled = var.data_validation_on_fargate_enabled
-  vpc_id                             = module.eks_subnets.vpc_id
+  vpc_id                             = module.subnets.vpc_id
 }
 
 module "subnets" {


### PR DESCRIPTION
In `databricks_sample`, the reference to the subnets module was incorrect in the `roles` variable, resulting in TF plan failure. Updating to the correct address.