### PR TITLE
Add terraform-docs config and github action.

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,39 @@
+name: Verify terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v5 # terraform-docs-go is a Go application
+      with:
+        go-version: 'stable' # Or a specific version if needed
+
+    - name: Install terraform-docs
+      run: go install github.com/terraform-docs/terraform-docs@v0.20.0 # Match version in pre-commit
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run terraform-docs via pre-commit
+      run: pre-commit run terraform-docs-go --all-files --config .pre-commit-config.yaml
+
+    - name: Check for documentation changes
+      run: |
+        git diff --exit-code
+        if [ $? -ne 0 ]; then
+          echo " Terraform documentation is not up-to-date. Please run 'pre-commit run terraform-docs-go --all-files' and commit the changes."
+          exit 1
+        fi
+        echo "Terraform documentation is up-to-date."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.20.0"
+    hooks:
+      - id: terraform-docs-go
+        name: terraform-docs-modules
+        args: ["-c", ".terraform-docs.yml", "./modules/"]
+      - id: terraform-docs-go
+        name: terraform-docs-deployment
+        args: ["-c", "deployment/.terraform-docs.yml", "./deployment/"]
+      - id: terraform-docs-go
+        name: terraform-docs-emr
+        args: ["-c", ".terraform-docs.yml", "./emr/"]
+      - id: terraform-docs-go
+        name: terraform-docs-rift_compute
+        args: ["-c", "rift_compute/.terraform-docs.yml", "./rift_compute/"]
+      - id: terraform-docs-go
+        name: terraform-docs-privatelink
+        args: ["-c", ".terraform-docs.yml", "./privatelink/"]

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,54 @@
+formatter: "markdown table" # this is required
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: true
+  path: "."
+  include-main: false
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  {{ .Header }}
+  {{ .Providers }}
+  {{ .Inputs }}  
+  {{ .Outputs }}
+
+ 
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/deployment/.terraform-docs.yml
+++ b/deployment/.terraform-docs.yml
@@ -1,0 +1,54 @@
+formatter: "markdown table" # this is required
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: "."
+  include-main: false
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  {{ .Header }}
+  {{ .Providers }}
+  {{ .Inputs }}  
+  {{ .Outputs }}
+
+ 
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,45 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.60 |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Data plane (customer) AWS account ID. | `string` | n/a | yes |
+| <a name="input_additional_offline_storage_tags"></a> [additional\_offline\_storage\_tags](#input\_additional\_offline\_storage\_tags) | **(Optional)** Additional tags for offline storage (S3 bucket) | `map(string)` | `{}` | no |
+| <a name="input_additional_s3_read_only_principals"></a> [additional\_s3\_read\_only\_principals](#input\_additional\_s3\_read\_only\_principals) | n/a | `list(string)` | `[]` | no |
+| <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | Server-side encryption algorithm to use. Valid values are AES256 and aws:kms.<br/> Note: (1) All resources should also be granted permission to decrypt with the KMS key if using KMS.<br/>       (2) If athena retrieval is used, the kms\_key option must also be set on the athena session. | `string` | `"AES256"` | no |
+| <a name="input_bucket_sse_key_enabled"></a> [bucket\_sse\_key\_enabled](#input\_bucket\_sse\_key\_enabled) | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `null` | no |
+| <a name="input_create_emr_roles"></a> [create\_emr\_roles](#input\_create\_emr\_roles) | Whether to create EMR roles. | `bool` | `false` | no |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | External ID for cross-account role assumption. | `string` | n/a | yes |
+| <a name="input_cross_account_role_allow_sts_metadata"></a> [cross\_account\_role\_allow\_sts\_metadata](#input\_cross\_account\_role\_allow\_sts\_metadata) | Enable sts:SetSourceIdentity and sts:TagSession permissions on the cross-role account. | `bool` | `false` | no |
+| <a name="input_databricks_spark_role_name"></a> [databricks\_spark\_role\_name](#input\_databricks\_spark\_role\_name) | n/a | `string` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the Tecton deployment. | `string` | n/a | yes |
+| <a name="input_emr_read_ecr_repositories"></a> [emr\_read\_ecr\_repositories](#input\_emr\_read\_ecr\_repositories) | List of ECR repositories that EMR roles are granted read access to. | `list(string)` | `[]` | no |
+| <a name="input_emr_spark_role_name"></a> [emr\_spark\_role\_name](#input\_emr\_spark\_role\_name) | Override the default name Tecton uses for emr spark role | `string` | `null` | no |
+| <a name="input_kms_key_additional_principals"></a> [kms\_key\_additional\_principals](#input\_kms\_key\_additional\_principals) | Additional set of principals to grant KMS key access to | `list(string)` | `[]` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | If provided, the ID of customer-managed key for encrypting data at rest | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region (of Tecton control plane _and_ data plane account). | `string` | n/a | yes |
+| <a name="input_s3_read_write_principals"></a> [s3\_read\_write\_principals](#input\_s3\_read\_write\_principals) | List of principals to grant read and write access to Tecton S3 bucket.<br/>Typically the AWS account running the materilization jobs | `list(string)` | n/a | yes |
+| <a name="input_satellite_region"></a> [satellite\_region](#input\_satellite\_region) | **(Optional)** Separate region for 'satellite' deployment. | `string` | `null` | no |
+| <a name="input_tecton_assuming_account_id"></a> [tecton\_assuming\_account\_id](#input\_tecton\_assuming\_account\_id) | The account Tecton will use to assume any cross-account roles. Typically the account ID of your Tecton control plane | `string` | `"153453085158"` | no |
+| <a name="input_use_rift_compute_on_control_plane"></a> [use\_rift\_compute\_on\_control\_plane](#input\_use\_rift\_compute\_on\_control\_plane) | Whether or not to enable Rift compute on control plane. | `bool` | `false` | no |
+| <a name="input_use_rift_cross_account_policy"></a> [use\_rift\_cross\_account\_policy](#input\_use\_rift\_cross\_account\_policy) | Whether or not to use rift version of IAM policies for cross-account access | `bool` | `null` | no |
+| <a name="input_use_spark_compute"></a> [use\_spark\_compute](#input\_use\_spark\_compute) | Whether or not to enable Spark compute | `bool` | `true` | no |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | ARN of the cross-account role Tecton control-plane will assume in your account. |
+| <a name="output_cross_account_role_name"></a> [cross\_account\_role\_name](#output\_cross\_account\_role\_name) | Name of cross-account role Tecton control-plane will assume in your account. |
+| <a name="output_emr_master_role_name"></a> [emr\_master\_role\_name](#output\_emr\_master\_role\_name) | *(Only included if create\_emr\_roles is true)* Name of the EMR master role. |
+| <a name="output_emr_spark_instance_profile_arn"></a> [emr\_spark\_instance\_profile\_arn](#output\_emr\_spark\_instance\_profile\_arn) | *(Only included if create\_emr\_roles is true)* ARN of the EMR Spark instance profile. |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used to encrypt the Tecton S3 bucket. |
+| <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | ARN of the Tecton offline store S3 bucket. |
+| <a name="output_spark_role_arn"></a> [spark\_role\_arn](#output\_spark\_role\_arn) | *(Only included if use\_spark\_compute is true)* ARN of the IAM role used for Spark compute. |
+| <a name="output_spark_role_name"></a> [spark\_role\_name](#output\_spark\_role\_name) | *(Only included if use\_spark\_compute is true)* Name of the IAM role used for Spark compute. |
+<!-- END_TF_DOCS -->

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,25 +1,39 @@
 output "cross_account_role_arn" {
+  description = "ARN of the cross-account role Tecton control-plane will assume in your account."
   value = aws_iam_role.cross_account_role.arn
 }
+
 output "cross_account_role_name" {
+  description = "Name of cross-account role Tecton control-plane will assume in your account."
   value = aws_iam_role.cross_account_role.name
 }
+
 output "spark_role_name" {
-  value = local.spark_role_name
+  description = "*(Only included if use_spark_compute is true)* Name of the IAM role used for Spark compute."
+  value = local.use_spark_compute ? local.spark_role_name : null
 }
+
 output "spark_role_arn" {
+  description = "*(Only included if use_spark_compute is true)* ARN of the IAM role used for Spark compute."
   value = local.use_spark_compute ? data.aws_iam_role.spark_role[0].arn : null
 }
+
 output "emr_master_role_name" {
+  description = "*(Only included if create_emr_roles is true)* Name of the EMR master role."
   value = var.create_emr_roles ? aws_iam_role.emr_master_role[0].name : null
 }
+
 output "emr_spark_instance_profile_arn" {
+  description = "*(Only included if create_emr_roles is true)* ARN of the EMR Spark instance profile."
   value = var.create_emr_roles ? aws_iam_instance_profile.emr_spark_instance_profile[0].arn : null
 }
+
 output "s3_bucket" {
+  description = "ARN of the Tecton offline store S3 bucket."
   value = aws_s3_bucket.tecton
 }
 
 output "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt the Tecton S3 bucket."
   value = local.kms_key_arn
 }

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,10 +1,13 @@
 variable "deployment_name" {
+  description = "Name of the Tecton deployment."
   type = string
 }
 variable "account_id" {
+  description = "Data plane (customer) AWS account ID."
   type = string
 }
 variable "region" {
+  description = "AWS region (of Tecton control plane _and_ data plane account)."
   type = string
 }
 
@@ -17,17 +20,22 @@ variable "s3_read_write_principals" {
 }
 
 variable "satellite_region" {
+  description = "**(Optional)** Separate region for 'satellite' deployment."
   type    = string
   default = null
 }
+
 variable "cross_account_external_id" {
   type = string
+  description = "External ID for cross-account role assumption."
 }
+
 variable "tecton_assuming_account_id" {
   type        = string
   description = "The account Tecton will use to assume any cross-account roles. Typically the account ID of your Tecton control plane"
   default     = "153453085158"
 }
+
 variable "databricks_spark_role_name" {
   type    = string
   default = null
@@ -37,8 +45,10 @@ variable "emr_spark_role_name" {
   description = "Override the default name Tecton uses for emr spark role"
   default     = null
 }
+
 variable "create_emr_roles" {
   type    = bool
+  description = "Whether to create EMR roles."
   default = false
 }
 variable "emr_read_ecr_repositories" {
@@ -53,7 +63,7 @@ variable "additional_s3_read_only_principals" {
 
 variable "additional_offline_storage_tags" {
   type        = map(string)
-  description = "Additional tags for offline storage (S3 bucket)"
+  description = "**(Optional)** Additional tags for offline storage (S3 bucket)"
   default     = {}
 }
 
@@ -75,7 +85,7 @@ variable "bucket_sse_key_enabled" {
 
 variable "kms_key_id" {
   type        = string
-  description = "If provided, ID of customer-managed key for encrypting data at rest"
+  description = "If provided, the ID of customer-managed key for encrypting data at rest"
   default     = null
 }
 
@@ -87,14 +97,14 @@ variable "kms_key_additional_principals" {
 
 variable "use_rift_cross_account_policy" {
   type        = bool
-  description = "(Deprecated in favor of var.use_rift_compute_on_control_plane) Whether or not to use rift version of IAM policies for cross-account access"
+  description = "Whether or not to use rift version of IAM policies for cross-account access"
   default     = null
   nullable    = true
 }
 
 variable "use_rift_compute_on_control_plane" {
   type        = bool
-  description = "Whether or not to enable Rift compute on control plane"
+  description = "Whether or not to enable Rift compute on control plane."
   default     = false
 }
 

--- a/emr/cross_account/README.md
+++ b/emr/cross_account/README.md
@@ -1,0 +1,20 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.60 |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zone_count"></a> [availability\_zone\_count](#input\_availability\_zone\_count) | n/a | `number` | `2` | no |
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | n/a | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_emr_instance_profile_name"></a> [emr\_instance\_profile\_name](#input\_emr\_instance\_profile\_name) | n/a | `string` | `"EMR_EC2_DefaultRole"` | no |
+| <a name="input_emr_service_role_name"></a> [emr\_service\_role\_name](#input\_emr\_service\_role\_name) | n/a | `string` | `"EMR_DefaultRole"` | no |
+| <a name="input_enable_notebook_cluster"></a> [enable\_notebook\_cluster](#input\_enable\_notebook\_cluster) | n/a | `bool` | n/a | yes |
+| <a name="input_glue_account_id"></a> [glue\_account\_id](#input\_glue\_account\_id) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |  
+<!-- END_TF_DOCS -->

--- a/emr/debugging/README.md
+++ b/emr/debugging/README.md
@@ -1,0 +1,17 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `string` | n/a | yes |
+| <a name="input_cross_account_role_name"></a> [cross\_account\_role\_name](#input\_cross\_account\_role\_name) | Set to your Tecton cross\_account\_role if you want to add permissions for Tecton engineers to debug your notebook code | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_log_uri_bucket"></a> [log\_uri\_bucket](#input\_log\_uri\_bucket) | The bucket name for the notebook cluster logs | `string` | n/a | yes |
+| <a name="input_log_uri_bucket_arn"></a> [log\_uri\_bucket\_arn](#input\_log\_uri\_bucket\_arn) | The bucket ARN for the notebook cluster logs | `string` | n/a | yes |  
+<!-- END_TF_DOCS -->

--- a/emr/notebook_cluster/README.md
+++ b/emr/notebook_cluster/README.md
@@ -1,0 +1,35 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap_tecton_emr_setup_args"></a> [bootstrap\_tecton\_emr\_setup\_args](#input\_bootstrap\_tecton\_emr\_setup\_args) | Args to be passed to the default EMR setup bootstrap script | `list(string)` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | This will be the same deployment name as used in the Tecton cluster installation | `string` | n/a | yes |
+| <a name="input_ebs_count"></a> [ebs\_count](#input\_ebs\_count) | Number of EBS volumes attached to EMR instances | `number` | `1` | no |
+| <a name="input_ebs_size"></a> [ebs\_size](#input\_ebs\_size) | Size of EBS volumes attached to EMR instances | `string` | `"40"` | no |
+| <a name="input_ebs_type"></a> [ebs\_type](#input\_ebs\_type) | Type of EBS volumes attached to EMR instances | `string` | `"gp2"` | no |
+| <a name="input_emr_security_group_id"></a> [emr\_security\_group\_id](#input\_emr\_security\_group\_id) | EMR security group | `string` | n/a | yes |
+| <a name="input_emr_service_role_id"></a> [emr\_service\_role\_id](#input\_emr\_service\_role\_id) | EMR service role | `string` | n/a | yes |
+| <a name="input_emr_service_security_group_id"></a> [emr\_service\_security\_group\_id](#input\_emr\_service\_security\_group\_id) | EMR service security group | `string` | n/a | yes |
+| <a name="input_extra_bootstrap_actions"></a> [extra\_bootstrap\_actions](#input\_extra\_bootstrap\_actions) | Additional bootstrap actions to perform upon EMR creation | `list(any)` | `[]` | no |
+| <a name="input_extra_cluster_config"></a> [extra\_cluster\_config](#input\_extra\_cluster\_config) | Additional EMR cluster configurations | `list(any)` | `[]` | no |
+| <a name="input_glue_account_id"></a> [glue\_account\_id](#input\_glue\_account\_id) | AWS account id containing the AWS Glue Catalog for cross-account access | `string` | n/a | yes |
+| <a name="input_has_glue"></a> [has\_glue](#input\_has\_glue) | Set to true if AWS Glue Catalog is set up and should be used to load Hive tables | `bool` | n/a | yes |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of EMR EC2 CORE instances to launch | `number` | `1` | no |
+| <a name="input_instance_profile_arn"></a> [instance\_profile\_arn](#input\_instance\_profile\_arn) | Underlying EC2 instance profile to use | `string` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EMR EC2 instance type | `string` | `"m5.xlarge"` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region, e.g. us-east-1 | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet to install EMR into | `string` | n/a | yes |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
+| <a name="output_logs_s3_bucket"></a> [logs\_s3\_bucket](#output\_logs\_s3\_bucket) | n/a |
+<!-- END_TF_DOCS -->

--- a/emr/redis/README.md
+++ b/emr/redis/README.md
@@ -1,0 +1,20 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_redis_security_group_id"></a> [redis\_security\_group\_id](#input\_redis\_security\_group\_id) | Security group for Redis | `string` | n/a | yes |
+| <a name="input_redis_subnet_id"></a> [redis\_subnet\_id](#input\_redis\_subnet\_id) | Subnet to install Redis into | `string` | n/a | yes |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_redis_configuration_endpoint"></a> [redis\_configuration\_endpoint](#output\_redis\_configuration\_endpoint) | n/a |
+<!-- END_TF_DOCS -->

--- a/emr/security_groups/README.md
+++ b/emr/security_groups/README.md
@@ -1,0 +1,22 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zone_count"></a> [availability\_zone\_count](#input\_availability\_zone\_count) | The number of availability zones for Tecton to use EMR in. | `number` | `2` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_emr_vpc_id"></a> [emr\_vpc\_id](#input\_emr\_vpc\_id) | Id of the vpc to create the security groups in. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region for Tecton to use EMR in. | `string` | n/a | yes |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_emr_security_group_id"></a> [emr\_security\_group\_id](#output\_emr\_security\_group\_id) | n/a |
+| <a name="output_emr_service_security_group_id"></a> [emr\_service\_security\_group\_id](#output\_emr\_service\_security\_group\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/emr/vpc_subnets/README.md
+++ b/emr/vpc_subnets/README.md
@@ -1,0 +1,24 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zone_count"></a> [availability\_zone\_count](#input\_availability\_zone\_count) | The number of availability zones for Tecton to use EMR in. | `number` | `2` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_emr_subnet_cidr_prefix"></a> [emr\_subnet\_cidr\_prefix](#input\_emr\_subnet\_cidr\_prefix) | The cidr block for the private and public subnets for this module to create. | `string` | `"10.38.0.0/16"` | no |
+| <a name="input_emr_vpc_id"></a> [emr\_vpc\_id](#input\_emr\_vpc\_id) | Id of a pre-existing VPC. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The region for Tecton to use EMR in. | `string` | n/a | yes |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_emr_subnet_id"></a> [emr\_subnet\_id](#output\_emr\_subnet\_id) | n/a |
+| <a name="output_emr_subnet_route_table_ids"></a> [emr\_subnet\_route\_table\_ids](#output\_emr\_subnet\_route\_table\_ids) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/controlplane_rift/README.md
+++ b/modules/controlplane_rift/README.md
@@ -39,23 +39,28 @@ module "tecton" {
 5.  Share the output values (like `cross_account_role_arn`) with your Tecton representative.
 
 ### Details
+<!-- BEGIN_TF_DOCS -->
 
-#### Inputs
 
-This module requires the following input variables:
+## Inputs
 
-*   `deployment_name`: (string) The name for your Tecton deployment (must be less than 22 characters).
-*   `region`: (string) The AWS region for the deployment (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Tecton resources will be deployed.
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane (from your Tecton rep).
-*   `cross_account_external_id`: (string) The external ID for cross-account access (from your Tecton rep).
-*   (Optional) `kms_key_id`: (string) The customer-managed key (ID) for encrypting data at rest.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | ID of the AWS account where Tecton will be deployed. | `string` | n/a | yes |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key (ID) for encrypting data at rest. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region for the Tecton deployment. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |  
+## Outputs
 
-#### Outputs
-
-The module will output several values, including:
-*   `cross_account_role_arn`: The ARN of the IAM role created for Tecton to access your account.
-*   `cross_account_external_id`: The external ID used (should match your input).
-*   `kms_key_arn`: ARN of the customer-managed key for encrypting data at rest.
+| Name | Description |
+|------|-------------|
+| <a name="output_cross_account_external_id"></a> [cross\_account\_external\_id](#output\_cross\_account\_external\_id) | n/a |
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | n/a |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+<!-- END_TF_DOCS -->
 
 These outputs need to be shared with your Tecton representative to complete the deployment.

--- a/modules/controlplane_rift/variables.tf
+++ b/modules/controlplane_rift/variables.tf
@@ -9,7 +9,7 @@ variable "region" {
 }
 
 variable "account_id" {
-  description = "The AWS account ID where Tecton will be deployed."
+  description = "ID of the AWS account where Tecton will be deployed."
   type        = string
 }
 

--- a/modules/controlplane_rift_with_emr/README.md
+++ b/modules/controlplane_rift_with_emr/README.md
@@ -59,37 +59,39 @@ This module provisions:
 ### Details
 
 #### Inputs
+<!-- BEGIN_TF_DOCS -->
 
-**Required Inputs:**
 
-*   `deployment_name`: (string) The name for your Tecton deployment (must be less than 22 characters). This name is used for various resources, including the S3 bucket.
-*   `region`: (string) The AWS region for the deployment (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Tecton data plane and EMR resources will be deployed.
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane (from your Tecton rep).
-*   `cross_account_external_id`: (string) The external ID for cross-account access (from your Tecton rep).
-*   (Optional) `kms_key_id`: (string) The customer-managed key (ID) for encrypting data at rest.
+## Inputs
 
-**Optional Inputs for EMR Notebook Cluster & Debugging:**
-NOTE: These can only be added _after_ the initial deployment setup process is complete.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
+| <a name="input_emr_debugging_count"></a> [emr\_debugging\_count](#input\_emr\_debugging\_count) | Set to 1 to allow Tecton to debug EMR clusters. Set to 0 to disable. Requires Tecton deployment. | `number` | `0` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
+| <a name="input_notebook_cluster_count"></a> [notebook\_cluster\_count](#input\_notebook\_cluster\_count) | Set to 1 to create the EMR notebook cluster. Set to 0 to disable. Requires Tecton deployment to be confirmed by your Tecton rep. | `number` | `0` | no |
+| <a name="input_notebook_extra_bootstrap_actions"></a> [notebook\_extra\_bootstrap\_actions](#input\_notebook\_extra\_bootstrap\_actions) | (Optional) List of extra bootstrap actions for the EMR notebook cluster. | <pre>list(object({<br/>    name = string<br/>    path = string<br/>  }))</pre> | `null` | no |
+| <a name="input_notebook_glue_account_id"></a> [notebook\_glue\_account\_id](#input\_notebook\_glue\_account\_id) | (Optional) The AWS account ID for Glue Data Catalog access. Defaults to the main account\_id if not specified. | `string` | `null` | no |
+| <a name="input_notebook_has_glue"></a> [notebook\_has\_glue](#input\_notebook\_has\_glue) | (Optional) Whether the EMR notebook cluster should have Glue Data Catalog access. | `bool` | `true` | no |
+| <a name="input_notebook_instance_type"></a> [notebook\_instance\_type](#input\_notebook\_instance\_type) | (Optional) The EC2 instance type for the EMR notebook cluster. | `string` | `"m5.xlarge"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region for the Tecton deployment. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |  
+## Outputs
 
-*   `notebook_cluster_count`: (number, default: `0`) Set to `1` to create an EMR notebook cluster. Requires Tecton deployment to be confirmed by your Tecton rep.
-*   `emr_debugging_count`: (number, default: `0`) Set to `1` to enable EMR debugging permissions for Tecton support. Requires Tecton deployment.
-*   `notebook_instance_type`: (string, default: `"m5.xlarge"`) The EC2 instance type for the EMR notebook cluster.
-*   `notebook_extra_bootstrap_actions`: (list(object), default: `null`) A list of extra bootstrap actions for the EMR notebook cluster. Each object should have `name` (string) and `path` (string, S3 path to script).
-*   `notebook_has_glue`: (bool, default: `true`) Whether the EMR notebook cluster should have Glue Data Catalog access.
-*   `notebook_glue_account_id`: (string, default: `null`) The AWS account ID for Glue Data Catalog access. If `null`, defaults to the main `account_id` provided.
-
-#### Outputs
-
-Key outputs from this module include:
-
-*   `cross_account_role_arn`: ARN of the IAM role for Tecton control plane access.
-*   `s3_bucket_name` (Note: This output is implicitly created by the underlying `deployment` module, usually `tecton-${var.deployment_name}` - you can get it from `module.tecton.s3_bucket.bucket`)
-*   `kms_key_arn`: ARN of the KMS key for data encryption.
-*   `spark_role_arn`: ARN of the IAM role for EMR Spark jobs.
-*   `spark_instance_profile_arn`: ARN of the instance profile for EMR EC2 instances.
-*   `vpc_id`: ID of the VPC created for EMR.
-*   `emr_subnet_id`: ID of the subnet for EMR clusters.
-*   `emr_security_group_id`: ID of the main EMR security group.
-*   `emr_service_security_group_id`: ID of the EMR service access security group.
-
+| Name | Description |
+|------|-------------|
+| <a name="output_cross_account_external_id"></a> [cross\_account\_external\_id](#output\_cross\_account\_external\_id) | n/a |
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | n/a |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_emr_security_group_id"></a> [emr\_security\_group\_id](#output\_emr\_security\_group\_id) | EMR security group outputs |
+| <a name="output_emr_service_security_group_id"></a> [emr\_service\_security\_group\_id](#output\_emr\_service\_security\_group\_id) | n/a |
+| <a name="output_emr_subnet_id"></a> [emr\_subnet\_id](#output\_emr\_subnet\_id) | n/a |
+| <a name="output_emr_subnet_route_table_ids"></a> [emr\_subnet\_route\_table\_ids](#output\_emr\_subnet\_route\_table\_ids) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_spark_instance_profile_arn"></a> [spark\_instance\_profile\_arn](#output\_spark\_instance\_profile\_arn) | n/a |
+| <a name="output_spark_role_arn"></a> [spark\_role\_arn](#output\_spark\_role\_arn) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | EMR VPC and subnet outputs |
+<!-- END_TF_DOCS -->

--- a/modules/databricks/README.md
+++ b/modules/databricks/README.md
@@ -51,30 +51,33 @@ module "tecton" {
 5.  Apply the configuration: `terraform apply`
 6.  Share the output values (like `cross_account_role_arn`, S3 bucket name from `module.tecton.s3_bucket.bucket`, `kms_key_arn`) with your Tecton representative. 
 
-#### Inputs
+### Details
+<!-- BEGIN_TF_DOCS -->
 
-This module requires the following input variables:
 
-*   `deployment_name`: (string) The name for your Tecton deployment (e.g., "my-tecton-for-databricks"). Must be less than 22 characters due to AWS S3 bucket naming limitations.
-*   `region`: (string) The AWS region where Tecton and Databricks resources are deployed (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Tecton and Databricks are deployed.
-*   `spark_role_name`: (string) The name of the existing IAM role used by your Databricks Spark jobs.
-*   `spark_instance_profile_name`: (string) The name of the existing IAM instance profile used by your Databricks clusters.
-*   `databricks_workspace_url`: (string) The URL of your Databricks workspace (e.g., `mycompany.cloud.databricks.com`).
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane (from your Tecton rep).
-*   `cross_account_external_id`: (string) The external ID for cross-account access by Tecton (from your Tecton rep).
-*   (Optional) `kms_key_id`: (string) The customer-managed key (ID) for encrypting data at rest.
+## Inputs
 
-#### Outputs
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton and Databricks are deployed. | `string` | n/a | yes |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access by Tecton. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_databricks_workspace_url"></a> [databricks\_workspace\_url](#input\_databricks\_workspace\_url) | The URL of your Databricks workspace (e.g., mycompany.cloud.databricks.com). | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name for your Tecton deployment. Must be less than 22 characters due to AWS S3 bucket naming limitations. | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where Tecton and Databricks resources are deployed. | `string` | n/a | yes |
+| <a name="input_spark_instance_profile_name"></a> [spark\_instance\_profile\_name](#input\_spark\_instance\_profile\_name) | The name of the IAM instance profile used by Databricks clusters. | `string` | n/a | yes |
+| <a name="input_spark_role_name"></a> [spark\_role\_name](#input\_spark\_role\_name) | The name of the IAM role used by Databricks for Spark jobs. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |  
+## Outputs
 
-Key outputs from this module include:
-
-*   `deployment_name`: The Tecton deployment name.
-*   `region`: The AWS region of the deployment.
-*   `cross_account_role_arn`: The ARN of the IAM role created for Tecton to access your account.
-*   `cross_account_external_id`: The external ID used for Tecton's cross-account access.
-*   `spark_role_name`: The Databricks Spark role name provided as input.
-*   `spark_instance_profile_name`: The Databricks instance profile name provided as input.
-*   `databricks_workspace_url`: The Databricks workspace URL provided as input.
-*   `kms_key_arn`: ARN of the customer-managed key for encrypting data at rest.
-
+| Name | Description |
+|------|-------------|
+| <a name="output_cross_account_external_id"></a> [cross\_account\_external\_id](#output\_cross\_account\_external\_id) | n/a |
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | n/a |
+| <a name="output_databricks_workspace_url"></a> [databricks\_workspace\_url](#output\_databricks\_workspace\_url) | The URL of your Databricks workspace. |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_spark_instance_profile_name"></a> [spark\_instance\_profile\_name](#output\_spark\_instance\_profile\_name) | n/a |
+| <a name="output_spark_role_name"></a> [spark\_role\_name](#output\_spark\_role\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/dataplane_rift/README.md
+++ b/modules/dataplane_rift/README.md
@@ -47,39 +47,45 @@ module "tecton" {
 4.  Apply the configuration: `terraform apply`
 5.  Share any required output values with your Tecton representative.
 
+### Details
 
-#### Inputs
+<!-- BEGIN_TF_DOCS -->
 
-This module requires the following input variables:
 
-*   `deployment_name`: (string) The name for your Tecton deployment (must be less than 22 characters).
-*   `region`: (string) The AWS region for the deployment (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Tecton resources will be deployed.
-*   `subnet_azs`: (list(string)) A list of Availability Zones for the Rift VPC subnets (e.g., `["us-west-2a", "us-west-2b", "us-west-2c"]`).
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane (from your Tecton rep).
-*   `cross_account_external_id`: (string) The external ID for cross-account access (from your Tecton rep).
-*   `tecton_control_plane_role_name`: (string) The name of the Tecton control plane IAM role (from your Tecton rep).
-*   (Optional) `kms_key_id`: (string) The customer-managed key (ID) for encrypting data at rest.
+## Inputs
 
-**Optional Inputs:**
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
+| <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. | `list(string)` | `null` | no |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region for the Tecton deployment. | `string` | n/a | yes |
+| <a name="input_subnet_azs"></a> [subnet\_azs](#input\_subnet\_azs) | A list of Availability Zones for the subnets. | `list(string)` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_role_name"></a> [tecton\_control\_plane\_role\_name](#input\_tecton\_control\_plane\_role\_name) | The name of the Tecton control plane IAM role. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_tecton_privatelink_egress_rules"></a> [tecton\_privatelink\_egress\_rules](#input\_tecton\_privatelink\_egress\_rules) | (Optional) List of egress rules for the Tecton PrivateLink security group. | <pre>list(object({<br/>    cidr        = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = string<br/>    description = string<br/>  }))</pre> | `null` | no |
+| <a name="input_tecton_privatelink_ingress_rules"></a> [tecton\_privatelink\_ingress\_rules](#input\_tecton\_privatelink\_ingress\_rules) | (Optional) List of ingress rules for the Tecton PrivateLink security group. | <pre>list(object({<br/>    cidr        = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = string<br/>    description = string<br/>  }))</pre> | `null` | no |
+| <a name="input_tecton_vpce_service_name"></a> [tecton\_vpce\_service\_name](#input\_tecton\_vpce\_service\_name) | (Optional) The VPC endpoint service name for Tecton. Only needed if using PrivateLink. | `string` | `null` | no |
+| <a name="input_use_network_firewall"></a> [use\_network\_firewall](#input\_use\_network\_firewall) | (Optional) Set to true to restrict egress from Rift compute using a network firewall. | `bool` | `false` | no |  
+## Outputs
 
-*   `tecton_vpce_service_name`: (string, default: `null`) The VPC endpoint service name for Tecton. Only needed if your Tecton deployment uses PrivateLink for control plane access.
-*   `tecton_privatelink_ingress_rules`: (list(object), default: `null`) Custom ingress rules for the Tecton PrivateLink VPC endpoint security group.
-    *   Each object has `cidr`, `from_port`, `to_port`, `protocol`, `description`.
-*   `tecton_privatelink_egress_rules`: (list(object), default: `null`) Custom egress rules for the Tecton PrivateLink VPC endpoint security group.
-    *   Each object has `cidr`, `from_port`, `to_port`, `protocol`, `description`.
-*   `use_network_firewall`: (bool, default: `false`) Set to `true` to enable an AWS Network Firewall in the Rift VPC with egress restrictions based on a list of allowed domains.
-*   `additional_allowed_egress_domains`: (list(string), default: `null`) If `use_network_firewall` is true, this list extends the default allowed egress domains.
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_docker_target_repo"></a> [anyscale\_docker\_target\_repo](#output\_anyscale\_docker\_target\_repo) | n/a |
+| <a name="output_compute_arn"></a> [compute\_arn](#output\_compute\_arn) | n/a |
+| <a name="output_compute_instance_profile_arn"></a> [compute\_instance\_profile\_arn](#output\_compute\_instance\_profile\_arn) | n/a |
+| <a name="output_compute_manager_arn"></a> [compute\_manager\_arn](#output\_compute\_manager\_arn) | n/a |
+| <a name="output_cross_account_external_id"></a> [cross\_account\_external\_id](#output\_cross\_account\_external\_id) | n/a |
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | n/a |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
+| <a name="output_nat_gateway_public_ips"></a> [nat\_gateway\_public\_ips](#output\_nat\_gateway\_public\_ips) | n/a |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_rift_compute_security_group_id"></a> [rift\_compute\_security\_group\_id](#output\_rift\_compute\_security\_group\_id) | n/a |
+| <a name="output_vm_workload_subnet_ids"></a> [vm\_workload\_subnet\_ids](#output\_vm\_workload\_subnet\_ids) | n/a |
+<!-- END_TF_DOCS -->
 
-#### Outputs
-
-Key outputs from this module include:
-
-*   `cross_account_role_arn`: The ARN of the IAM role created for Tecton to access your data plane account.
-*   `compute_manager_arn`: ARN of the Rift compute manager IAM role.
-*   `compute_instance_profile_arn`: ARN of the Rift compute instance profile.
-*   `rift_compute_security_group_id`: ID of the security group for Rift compute instances.
-*   `nat_gateway_public_ips`: Public IP addresses of the NAT Gateways used by the Rift VPC.
-*   `kms_key_arn`: ARN of the customer-managed key for encrypting data at rest.
 
 These outputs need to be shared with your Tecton representative to complete the deployment.

--- a/modules/emr/README.md
+++ b/modules/emr/README.md
@@ -57,41 +57,50 @@ Before using this module, ensure you have:
     *   Tecton Control Plane Account ID
     *   Cross-Account External ID
 
-#### Inputs
+### Details
 
-**Required Inputs:**
+<!-- BEGIN_TF_DOCS -->
 
-*   `deployment_name`: (string) A unique name for your Tecton deployment (e.g., "my-tecton-emr"). This name is used for various resources, including the S3 bucket. Must be less than 22 characters.
-*   `region`: (string) The AWS region for the Tecton and EMR deployment (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Tecton and EMR resources will be deployed.
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane (from your Tecton rep).
-*   `cross_account_external_id`: (string) The external ID for cross-account access by Tecton (from your Tecton rep).
-*   (Optional) `kms_key_id`: (string) The customer-managed key (ID) for encrypting data at rest.
+## Providers
 
-**Optional Inputs:**
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.60 |
+## Inputs
 
-*   `enable_redis`: (bool, default: `false`) Set to `true` to deploy Redis as an online store. If `false`, DynamoDB is used by default.
-*   `enable_notebook_cluster`: (bool, default: `false`) Set to `true` to create an EMR notebook cluster. Tecton deployment needs to be confirmed by your Tecton rep first.
-*   `enable_emr_debugging`: (bool, default: `false`) Set to `true` to enable EMR debugging permissions for Tecton support. Requires `enable_notebook_cluster` to be `true`.
-*   `notebook_instance_type`: (string, default: `"m5.xlarge"`) EC2 instance type for the EMR notebook cluster.
-*   `notebook_extra_bootstrap_actions`: (list(object), default: `null`) Extra bootstrap actions for the EMR notebook cluster. Each object: `name` (string), `path` (string, S3 URI).
-*   `notebook_has_glue`: (bool, default: `true`) Whether the EMR notebook cluster should have Glue Data Catalog access.
-*   `notebook_glue_account_id`: (string, default: `null`) AWS account ID for Glue Data Catalog access for notebooks. Defaults to `var.account_id` if `null` and `notebook_has_glue` is true.
-*   `cross_account_principal_arn_for_s3_policy`: (string, default: `null`) (Advanced) ARN of a principal in another account for read-only S3 bucket access. Used for custom cross-account EMR setups.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton and EMR resources will be deployed. | `string` | n/a | yes |
+| <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access by Tecton. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_cross_account_principal_arn_for_s3_policy"></a> [cross\_account\_principal\_arn\_for\_s3\_policy](#input\_cross\_account\_principal\_arn\_for\_s3\_policy) | (Optional) The ARN of the principal in another account that should get read-only access to the Tecton S3 bucket. Used if setting up cross-account EMR notebooks manually or extending this module. | `string` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name for your Tecton deployment. Must be less than 22 characters due to AWS S3 bucket naming limitations. | `string` | n/a | yes |
+| <a name="input_emr_notebook_cross_account_external_id"></a> [emr\_notebook\_cross\_account\_external\_id](#input\_emr\_notebook\_cross\_account\_external\_id) | (Optional) The external ID for cross-account access by the EMR notebook cluster. | `string` | `null` | no |
+| <a name="input_emr_notebook_cross_account_region"></a> [emr\_notebook\_cross\_account\_region](#input\_emr\_notebook\_cross\_account\_region) | (Optional) The AWS region of the cross-account EMR notebook cluster. | `string` | `null` | no |
+| <a name="input_emr_notebook_cross_account_role_arn"></a> [emr\_notebook\_cross\_account\_role\_arn](#input\_emr\_notebook\_cross\_account\_role\_arn) | (Optional) The ARN of the role in the cross-account EMR notebook cluster. | `string` | `null` | no |
+| <a name="input_enable_cross_account_emr_notebook_cluster"></a> [enable\_cross\_account\_emr\_notebook\_cluster](#input\_enable\_cross\_account\_emr\_notebook\_cluster) | (Optional) Set to true to include a cross-account EMR notebook cluster. Requires also setting: emr\_notebook\_cross\_account\_region, emr\_notebook\_cross\_account\_role\_arn, emr\_notebook\_cross\_account\_external\_id, and cross\_account\_principal\_arn\_for\_s3\_policy. | `bool` | `false` | no |
+| <a name="input_enable_emr_debugging"></a> [enable\_emr\_debugging](#input\_enable\_emr\_debugging) | Set to true to enable EMR debugging permissions for Tecton support. Requires enable\_notebook\_cluster to be true. | `bool` | `false` | no |
+| <a name="input_enable_notebook_cluster"></a> [enable\_notebook\_cluster](#input\_enable\_notebook\_cluster) | Set to true to create an EMR notebook cluster. Requires Tecton deployment to be confirmed by your Tecton rep. | `bool` | `false` | no |
+| <a name="input_enable_redis"></a> [enable\_redis](#input\_enable\_redis) | Set to true to deploy Redis as an online store. Default is false (DynamoDB is used). | `bool` | `false` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
+| <a name="input_notebook_extra_bootstrap_actions"></a> [notebook\_extra\_bootstrap\_actions](#input\_notebook\_extra\_bootstrap\_actions) | (Optional) List of extra bootstrap actions for the EMR notebook cluster. | <pre>list(object({<br/>    name = string<br/>    path = string # S3 path to the script<br/>  }))</pre> | `null` | no |
+| <a name="input_notebook_glue_account_id"></a> [notebook\_glue\_account\_id](#input\_notebook\_glue\_account\_id) | (Optional) The AWS account ID for Glue Data Catalog access for the notebook. Defaults to the main account\_id if not specified (and notebook\_has\_glue is true). | `string` | `null` | no |
+| <a name="input_notebook_has_glue"></a> [notebook\_has\_glue](#input\_notebook\_has\_glue) | (Optional) Whether the EMR notebook cluster should have Glue Data Catalog access. | `bool` | `true` | no |
+| <a name="input_notebook_instance_type"></a> [notebook\_instance\_type](#input\_notebook\_instance\_type) | (Optional) The EC2 instance type for the EMR notebook cluster. | `string` | `"m5.xlarge"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region for the Tecton and EMR deployment. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |  
+## Outputs
 
-#### Outputs
+| Name | Description |
+|------|-------------|
+| <a name="output_cross_account_external_id"></a> [cross\_account\_external\_id](#output\_cross\_account\_external\_id) | n/a |
+| <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | n/a |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
+| <a name="output_notebook_cluster_id"></a> [notebook\_cluster\_id](#output\_notebook\_cluster\_id) | The ID of the EMR notebook cluster, if created. |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_spark_instance_profile_arn"></a> [spark\_instance\_profile\_arn](#output\_spark\_instance\_profile\_arn) | n/a |
+| <a name="output_spark_role_arn"></a> [spark\_role\_arn](#output\_spark\_role\_arn) | n/a |
+<!-- END_TF_DOCS -->
 
-Key outputs from this module include:
 
-*   `deployment_name`: The Tecton deployment name.
-*   `region`: The AWS region of the deployment.
-*   `cross_account_role_arn`: ARN of the IAM role for Tecton control plane access.
-*   `cross_account_external_id`: External ID used for Tecton's access.
-*   `spark_role_arn`: ARN of the IAM role for EMR Spark jobs.
-*   `spark_instance_profile_arn`: ARN of the instance profile for EMR EC2 instances.
-*   `kms_key_arn`: ARN of the KMS key for Tecton data encryption.
-*   `notebook_cluster_id`: The ID of the EMR notebook cluster, if created (empty string otherwise).
-*   (Implicitly, S3 bucket name: `module.tecton.s3_bucket.bucket`)
-*   (Implicitly, VPC ID: `module.subnets.vpc_id`, EMR Subnet ID: `module.subnets.emr_subnet_id`)
-*   (Implicitly, EMR Security Group IDs: `module.security_groups.emr_security_group_id`, `module.security_groups.emr_service_security_group_id`)
-
+These outputs need to be shared with your Tecton representative to complete the deployment.

--- a/modules/standalone_rift/README.md
+++ b/modules/standalone_rift/README.md
@@ -53,34 +53,40 @@ module "rift" {
 5.  Apply the configuration: `terraform apply`
 6.  Verify the new Rift compute resources and their integration with your Tecton control plane.
 
-#### Inputs
+### Details
 
-**Required Inputs:**
+<!-- BEGIN_TF_DOCS -->
 
-*   `deployment_name`: (string) A unique name for this specific Rift deployment (e.g., "my-rift-compute"). This is used for naming resources created by this module.
-*   `region`: (string) The AWS region where Rift resources will be deployed (e.g., "us-west-2").
-*   `account_id`: (string) Your AWS account ID where Rift resources will be deployed.
-*   `subnet_azs`: (list(string)) A list of Availability Zones for the Rift VPC subnets (e.g., `["us-west-2a", "us-west-2b", "us-west-2c"]`).
-*   `tecton_control_plane_account_id`: (string) The AWS account ID of the Tecton control plane.
-*   `tecton_control_plane_role_name`: (string) The name of the Tecton control plane IAM role that Rift will allow to assume its manager role.
-*   `log_bucket_name`: (string) The name of your existing S3 bucket where Rift logs will be stored.
-*   `offline_store_bucket_name`: (string) The name of your existing S3 bucket used as the offline store.
 
-**Optional Inputs:**
+## Inputs
 
-*   `tecton_vpce_service_name`: (string, default: `null`) The VPC endpoint service name for accessing the Tecton control plane. Required if your control plane uses PrivateLink.
-*   `use_network_firewall`: (bool, default: `false`) Set to `true` to enable an AWS Network Firewall in the Rift VPC with egress restrictions.
-*   `additional_allowed_egress_domains`: (list(string), default: `null`) If `use_network_firewall` is true, this list extends the default allowed egress domains.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Rift resources will be deployed. | `string` | n/a | yes |
+| <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. | `list(string)` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | A unique name for this Rift deployment, used for naming resources. Must be less than 22 characters due to AWS limitations if used for S3 bucket naming. | `string` | n/a | yes |
+| <a name="input_log_bucket_name"></a> [log\_bucket\_name](#input\_log\_bucket\_name) | The name of the S3 bucket where Rift logs will be stored. | `string` | n/a | yes |
+| <a name="input_offline_store_bucket_name"></a> [offline\_store\_bucket\_name](#input\_offline\_store\_bucket\_name) | The name of the S3 bucket used as the offline store. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region for the Rift deployment. | `string` | n/a | yes |
+| <a name="input_subnet_azs"></a> [subnet\_azs](#input\_subnet\_azs) | A list of Availability Zones for the Rift VPC subnets. | `list(string)` | n/a | yes |
+| <a name="input_tecton_control_plane_account_id"></a> [tecton\_control\_plane\_account\_id](#input\_tecton\_control\_plane\_account\_id) | The AWS account ID of the Tecton control plane. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_tecton_control_plane_role_name"></a> [tecton\_control\_plane\_role\_name](#input\_tecton\_control\_plane\_role\_name) | The name of the Tecton control plane IAM role that Rift will allow to assume its manager role. Obtain this from your Tecton representative. | `string` | n/a | yes |
+| <a name="input_tecton_vpce_service_name"></a> [tecton\_vpce\_service\_name](#input\_tecton\_vpce\_service\_name) | (Optional) The VPC endpoint service name for Tecton. Required if the Tecton control plane uses PrivateLink for ingress. | `string` | `null` | no |
+| <a name="input_use_network_firewall"></a> [use\_network\_firewall](#input\_use\_network\_firewall) | (Optional) Set to true to restrict egress from Rift compute using an AWS Network Firewall. | `bool` | `false` | no |  
+## Outputs
 
-#### Outputs
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_docker_target_repo"></a> [anyscale\_docker\_target\_repo](#output\_anyscale\_docker\_target\_repo) | n/a |
+| <a name="output_compute_arn"></a> [compute\_arn](#output\_compute\_arn) | n/a |
+| <a name="output_compute_instance_profile_arn"></a> [compute\_instance\_profile\_arn](#output\_compute\_instance\_profile\_arn) | n/a |
+| <a name="output_compute_manager_arn"></a> [compute\_manager\_arn](#output\_compute\_manager\_arn) | n/a |
+| <a name="output_deployment_name"></a> [deployment\_name](#output\_deployment\_name) | n/a |
+| <a name="output_nat_gateway_public_ips"></a> [nat\_gateway\_public\_ips](#output\_nat\_gateway\_public\_ips) | n/a |
+| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_rift_compute_security_group_id"></a> [rift\_compute\_security\_group\_id](#output\_rift\_compute\_security\_group\_id) | n/a |
+| <a name="output_vm_workload_subnet_ids"></a> [vm\_workload\_subnet\_ids](#output\_vm\_workload\_subnet\_ids) | n/a |
+<!-- END_TF_DOCS -->
 
-Key outputs from this module include:
 
-*   `compute_manager_arn`: ARN of the Rift compute manager IAM role.
-*   `compute_instance_profile_arn`: ARN of the Rift compute instance profile.
-*   `rift_compute_security_group_id`: ID of the security group for Rift compute instances.
-*   `nat_gateway_public_ips`: Public IP addresses of the NAT Gateways used by the Rift VPC.
-*   `vm_workload_subnet_ids`: List of subnet IDs for VM workloads.
-
-These outputs might be needed for configuring Tecton or for your own reference.
-
+These outputs need to be shared with your Tecton representative to complete the deployment.

--- a/privatelink/cross_vpc/README.md
+++ b/privatelink/cross_vpc/README.md
@@ -41,45 +41,24 @@ module "privatelink-cross-vpc" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_route53_record.cluster_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_zone.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
-| [aws_security_group.cross_vpc_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_vpc_endpoint.cross_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | DNS name for Tecton servcies | `string` | n/a | yes |
-| <a name="input_vpc_endpoint_security_group_egress_cidrs"></a> [vpc\_endpoint\_security\_group\_egress\_cidrs](#input\_vpc\_endpoint\_security\_group\_egress\_cidrs) | Egress CIDR blocks of the VPC endpiont security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| <a name="input_vpc_endpoint_security_group_ingress_cidrs"></a> [vpc\_endpoint\_security\_group\_ingress\_cidrs](#input\_vpc\_endpoint\_security\_group\_ingress\_cidrs) | Ingress CIDR blocks of the VPC endpiont security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | DNS name for Tecton services | `string` | n/a | yes |
+| <a name="input_enable_vpc_endpoint_private_dns"></a> [enable\_vpc\_endpoint\_private\_dns](#input\_enable\_vpc\_endpoint\_private\_dns) | Enables private DNS on the VPC endpoint rather than creating a route53 private hosted zone & record. Setting this requires that the associated VPC endpoint service has private DNS enabled. Please confirm with your Tecton rep prior to setting this. | `bool` | `false` | no |
+| <a name="input_vpc_endpoint_security_group_egress_cidrs"></a> [vpc\_endpoint\_security\_group\_egress\_cidrs](#input\_vpc\_endpoint\_security\_group\_egress\_cidrs) | Egress CIDR blocks of the VPC endpoint security group | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_vpc_endpoint_security_group_ingress_cidrs"></a> [vpc\_endpoint\_security\_group\_ingress\_cidrs](#input\_vpc\_endpoint\_security\_group\_ingress\_cidrs) | Ingress CIDR blocks of the VPC endpoint security group | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_vpc_endpoint_security_group_name"></a> [vpc\_endpoint\_security\_group\_name](#input\_vpc\_endpoint\_security\_group\_name) | Name of the VPC endpoint security group | `string` | `"tecton-services-vpc-endpoint"` | no |
 | <a name="input_vpc_endpoint_service_name"></a> [vpc\_endpoint\_service\_name](#input\_vpc\_endpoint\_service\_name) | Name of the pre-existing VPC endpoint service to connect to | `string` | n/a | yes |
-| <a name="input_vpc_endpoint_subnet_ids"></a> [vpc\_endpoint\_subnet\_ids](#input\_vpc\_endpoint\_subnet\_ids) | Private subnet ids where to create VPC endpiont | `list(string)` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID from which to create the VPC endpoint | `string` | n/a | yes |
-
+| <a name="input_vpc_endpoint_subnet_ids"></a> [vpc\_endpoint\_subnet\_ids](#input\_vpc\_endpoint\_subnet\_ids) | Private subnet ids where to create VPC endpoint | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID from which to create the VPC endpoint | `string` | n/a | yes |  
 ## Outputs
 
 | Name | Description |

--- a/rift_compute/.terraform-docs.yml
+++ b/rift_compute/.terraform-docs.yml
@@ -1,0 +1,54 @@
+formatter: "markdown table" # this is required
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: "."
+  include-main: false
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  {{ .Header }}
+  {{ .Providers }}
+  {{ .Inputs }}  
+  {{ .Outputs }}
+
+ 
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: true
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/rift_compute/README.md
+++ b/rift_compute/README.md
@@ -1,0 +1,42 @@
+<!-- BEGIN_TF_DOCS -->
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | Additional domains to allow egress to (if using network firewall) | `list(string)` | `[]` | no |
+| <a name="input_additional_rift_compute_policy_statements"></a> [additional\_rift\_compute\_policy\_statements](#input\_additional\_rift\_compute\_policy\_statements) | Additional IAM policy statements to attach to the rift\_compute role | `list(any)` | `[]` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Tecton deployment. | `string` | n/a | yes |
+| <a name="input_control_plane_account_id"></a> [control\_plane\_account\_id](#input\_control\_plane\_account\_id) | Account ID of the account Orchestrator will be running in. Used to grant ECR permissions. | `string` | `null` | no |
+| <a name="input_enable_rift_legacy_secret_manager_access"></a> [enable\_rift\_legacy\_secret\_manager\_access](#input\_enable\_rift\_legacy\_secret\_manager\_access) | Flag to indicate if supporting legacy secret management or not. Directly accessing secret manager from Rift jobs is no longer supported. Tecton Secrets should be used instead | `bool` | `false` | no |
+| <a name="input_is_internal_workload"></a> [is\_internal\_workload](#input\_is\_internal\_workload) | Flag to indicate if the workload is internal to Tecton. Set it to true if for dev and demo clusters. | `bool` | `false` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | ARN of KMS key used to encrypt online/offline feature store. | `string` | `null` | no |
+| <a name="input_offline_store_bucket_arn"></a> [offline\_store\_bucket\_arn](#input\_offline\_store\_bucket\_arn) | ARN of offline store bucket. | `string` | n/a | yes |
+| <a name="input_offline_store_key_prefix"></a> [offline\_store\_key\_prefix](#input\_offline\_store\_key\_prefix) | Prefix used for offline store keys. | `string` | `"offline-store/"` | no |
+| <a name="input_resource_name_overrides"></a> [resource\_name\_overrides](#input\_resource\_name\_overrides) | map of Terraform resource names, to cloud provider names. Used to override any named resource. | `map(string)` | `{}` | no |
+| <a name="input_rift_compute_manager_assuming_role_arns"></a> [rift\_compute\_manager\_assuming\_role\_arns](#input\_rift\_compute\_manager\_assuming\_role\_arns) | ARNs of the IAM roles that will be assuming `tecton-rift-compute-manager` to start rift materialization jobs. Typically `eks-worker-node`. | `list(string)` | n/a | yes |
+| <a name="input_s3_log_destination"></a> [s3\_log\_destination](#input\_s3\_log\_destination) | S3 destination for rift job logs, Example: arn:aws:s3:::tecton-log-bucket/rift-logs | `string` | n/a | yes |
+| <a name="input_subnet_azs"></a> [subnet\_azs](#input\_subnet\_azs) | List of AZs to create subnets in. | `list(string)` | n/a | yes |
+| <a name="input_tecton_privatelink_egress_rules"></a> [tecton\_privatelink\_egress\_rules](#input\_tecton\_privatelink\_egress\_rules) | List of egress rules for the Tecton PrivateLink security group. If empty, all traffic is allowed. | <pre>list(object({<br/>    cidr        = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = string<br/>    description = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_tecton_privatelink_ingress_rules"></a> [tecton\_privatelink\_ingress\_rules](#input\_tecton\_privatelink\_ingress\_rules) | List of custom ingress rules for the Tecton PrivateLink endpoint security group with CIDR, ports, and protocol. If empty, a default 'allow all' rule will be created. | <pre>list(object({<br/>    cidr        = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = string<br/>    description = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_tecton_vpce_service_name"></a> [tecton\_vpce\_service\_name](#input\_tecton\_vpce\_service\_name) | VPC Endpoint service name for deployments w/ PrivateLink enabled. Required if materialization jobs need to connect to Tecton webui/apis (i.e. for Tecton Secrets) | `string` | `null` | no |
+| <a name="input_use_network_firewall"></a> [use\_network\_firewall](#input\_use\_network\_firewall) | If true, will use AWS Network Firewall to restrict egress. | `bool` | `false` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block for the VPC (e.g. 10.0.0.0/16) | `string` | `"10.0.0.0/16"` | no |  
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_anyscale_docker_target_repo"></a> [anyscale\_docker\_target\_repo](#output\_anyscale\_docker\_target\_repo) | ECR repository URL for Rift compute |
+| <a name="output_compute_arn"></a> [compute\_arn](#output\_compute\_arn) | ARN of the IAM role for Rift compute |
+| <a name="output_compute_instance_profile_arn"></a> [compute\_instance\_profile\_arn](#output\_compute\_instance\_profile\_arn) | ARN of the IAM instance profile for Rift compute |
+| <a name="output_compute_manager_arn"></a> [compute\_manager\_arn](#output\_compute\_manager\_arn) | ARN of the IAM role for Rift compute manager |
+| <a name="output_nat_gateway_public_ips"></a> [nat\_gateway\_public\_ips](#output\_nat\_gateway\_public\_ips) | List of public IPs associated with NAT gateways in Rift VPC |
+| <a name="output_rift_compute_security_group_id"></a> [rift\_compute\_security\_group\_id](#output\_rift\_compute\_security\_group\_id) | Security Group ID for Rift compute instances |
+| <a name="output_rift_ecr_repo_arn"></a> [rift\_ecr\_repo\_arn](#output\_rift\_ecr\_repo\_arn) | ARN of the ECR repository for Rift compute |
+| <a name="output_vm_workload_subnet_ids"></a> [vm\_workload\_subnet\_ids](#output\_vm\_workload\_subnet\_ids) | List (comma-separated string) of subnet IDs for Rift compute instances |
+<!-- END_TF_DOCS -->

--- a/rift_compute/outputs.tf
+++ b/rift_compute/outputs.tf
@@ -1,40 +1,41 @@
 ## Pass to Tecton rep
 
 output "compute_manager_arn" {
-  # input for module/tecton-saas: `ray_cluster_manager_arn`
-  # input for kustomization.yaml: `RAY_CLUSTER_MANAGER_ROLE`
+  description = "ARN of the IAM role for Rift compute manager"
   value = aws_iam_role.rift_compute_manager.arn
 }
 
 output "compute_instance_profile_arn" {
-  # input for kustomization.yaml: `RAY_INSTANCE_PROFILE`
+  description = "ARN of the IAM instance profile for Rift compute"
   value = aws_iam_instance_profile.rift_compute.arn
 }
 
 output "compute_arn" {
-  # input for CFT `s3_read_write_principals`
+  description = "ARN of the IAM role for Rift compute"
   value = aws_iam_role.rift_compute.arn
 }
 
 output "vm_workload_subnet_ids" {
-  # input for kustomization.yaml: `RAY_INSTANCE_PROFILE`
+  description = "List (comma-separated string) of subnet IDs for Rift compute instances"
   value = join(",", [for subnet in aws_subnet.private : subnet.id])
 }
 
 output "anyscale_docker_target_repo" {
-  # input for kustomization.yaml: `ANYSCALE_DOCKER_TARGET_REPO`
+  description = "ECR repository URL for Rift compute"
   value = aws_ecr_repository.rift_env.repository_url
 }
 
 output "rift_ecr_repo_arn" {
+  description = "ARN of the ECR repository for Rift compute"
   value = aws_ecr_repository.rift_env.arn
 }
 
 output "nat_gateway_public_ips" {
-  description = "List of public IPs associated with the NAT Gateways"
+  description = "List of public IPs associated with NAT gateways in Rift VPC"
   value       = [for eip in aws_eip.rift : eip.public_ip]
 }
 
 output "rift_compute_security_group_id" {
+  description = "Security Group ID for Rift compute instances"
   value = aws_security_group.rift_compute.id
 }

--- a/rift_compute/variables.tf
+++ b/rift_compute/variables.tf
@@ -1,6 +1,6 @@
 variable "cluster_name" {
   type        = string
-  description = "Name of the Tecton cluster."
+  description = "Name of the Tecton deployment."
 }
 
 variable "rift_compute_manager_assuming_role_arns" {


### PR DESCRIPTION
1. Adding [terraform-docs](https://terraform-docs.io/) configuration (taken from [here](https://terraform-docs.io/user-guide/configuration/#options) and modified), pre-commit config,  and Github Action to check that it was run.
   * Injects sections into existing readmes if they exist (between `<!-- BEGIN_TF_DOCS -->` and `<!-- END_TF_DOCS -->`). To this end, removed the previous manually written input/output sections (from #199) and replaced with these^ placeholders, where terraform-docs added its sections.
 

2. Updating variable descriptions for `deployment` module.


GH action [ran here](https://github.com/tecton-ai/tecton-terraform-setup/actions/runs/15122900685/job/42509120690) readme changes are included in this PR.