### PR TITLE
style: Convert rift-compute-manager and rift-compute policies from HCL to json template.

### DIFF
--- a/rift_compute/iam.tf
+++ b/rift_compute/iam.tf
@@ -19,153 +19,21 @@ resource "aws_iam_role" "rift_compute_manager" {
   })
 }
 
-data "aws_iam_policy_document" "manage_rift_compute" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:StopInstances",
-      "ec2:TerminateInstances",
-      "ec2:CreateTags",
-    ]
-    resources = [
-      "arn:aws:ec2:*:${local.account_id}:instance/*",
-    ]
-    condition {
-      test     = "Null"
-      variable = "ec2:ResourceTag/tecton_rift_workflow_id"
-      values   = ["false"]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:StartInstances",
-      "ec2:RunInstances",
-    ]
-    resources = [
-      "arn:aws:ec2:*:${local.account_id}:instance/*",
-    ]
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/tecton_rift_workflow_id"
-      values   = ["false"]
-    }
-  }
-
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:CreateTags",
-      "ec2:DeleteTags"
-    ]
-    # Describe* permissions do not support resource-level permissions:
-    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:RunInstances",
-    ]
-    resources = flatten([
+resource "aws_iam_policy" "manage_rift_compute" {
+  name   = lookup(var.resource_name_overrides, "manage_rift_compute", "manage-rift-compute")
+  policy = templatefile("${path.module}/../templates/manage_rift_compute_policy.json", {
+    ACCOUNT_ID                  = local.account_id,
+    RIFT_COMPUTE_ROLE_ARN       = aws_iam_role.rift_compute.arn,
+    ALLOW_RUN_INSTANCES_RESOURCES = jsonencode(flatten([
       "arn:aws:ec2:*:${local.account_id}:volume/*",
       aws_security_group.rift_compute.arn,
       [for subnet in aws_subnet.private : subnet.arn],
-    ])
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:RunInstances",
-      "ec2:DeleteNetworkInterface"
-    ]
-    resources = [
-      "arn:aws:ec2:*:${local.account_id}:network-interface/*"
-    ]
-    condition {
-      test     = "Null"
-      variable = "ec2:ResourceTag/tecton_rift_workflow_id"
-      values   = ["false"]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:CreateNetworkInterface"
-    ]
-    resources = [
-      "arn:aws:ec2:*:${local.account_id}:network-interface/*"
-    ]
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/tecton_rift_workflow_id"
-      values   = ["false"]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:CreateNetworkInterface",
-    ]
-    resources = flatten([
+    ])),
+    ALLOW_NETWORK_INTERFACE_RESOURCES = jsonencode(flatten([
       aws_security_group.rift_compute.arn,
       [for subnet in aws_subnet.private : subnet.arn],
-    ])
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:RunInstances",
-    ]
-    resources = [
-      "arn:aws:ec2:*::image/*"
-    ]
-    condition {
-      test     = "StringEquals"
-      variable = "ec2:Owner"
-      values   = ["amazon", "472542229217"]
-    }
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.rift_compute.arn]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:GetParameters"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "servicequotas:GetServiceQuota"
-    ]
-    resources = [
-      "arn:aws:servicequotas:*:${local.account_id}:ec2/L-1216C47A"
-    ]
-  }
-}
-
-resource "aws_iam_policy" "manage_rift_compute" {
-  name   = lookup(var.resource_name_overrides, "manage_rift_compute", "manage-rift-compute")
-  policy = data.aws_iam_policy_document.manage_rift_compute.json
+    ]))
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "rift_compute_manager_policies" {
@@ -198,234 +66,56 @@ resource "aws_iam_instance_profile" "rift_compute" {
 
 resource "aws_iam_policy" "rift_dynamodb_access" {
   name = "tecton-rift-dynamodb-access"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "dynamodb:BatchGetItem",
-          "dynamodb:BatchWriteItem",
-          "dynamodb:CreateTable",
-          "dynamodb:DeleteItem",
-          "dynamodb:DescribeTable",
-          "dynamodb:GetItem",
-          "dynamodb:PutItem",
-          "dynamodb:UpdateItem",
-          "dynamodb:Query"
-        ]
-        Resource = [
-          "arn:aws:dynamodb:*:${local.account_id}:table/tecton-*",
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "sts:AssumeRole"
-        ]
-        # Used for assume into cross-account-intermediary role when Rift is in control plane account.
-        Resource = ["arn:aws:iam::${local.account_id}:role/${var.cluster_name}-cross-account-intermediate"]
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_dynamodb_access_policy.json", {
+    ACCOUNT_ID   = local.account_id,
+    CLUSTER_NAME = var.cluster_name
   })
 }
 
 resource "aws_iam_policy" "rift_legacy_secrets_manager_access" {
   count = var.enable_rift_legacy_secret_manager_access ? 1 : 0
   name = "tecton-rift-legacy-secrets-manager-access"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-            "secretsmanager:*"
-        ]
-        Resource = [
-          "arn:aws:secretsmanager:*:${local.account_id}:secret:tecton-*",
-        ]
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_legacy_secrets_manager_access_policy.json", {
+    ACCOUNT_ID = local.account_id
   })
 }
 
 resource "aws_iam_policy" "rift_ecr_readonly" {
   name = "tecton-rift-ecr-readonly"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:GetRepositoryPolicy",
-          "ecr:DescribeRepositories",
-          "ecr:ListImages",
-          "ecr:DescribeImages",
-          "ecr:BatchGetImage",
-          "ecr:GetLifecyclePolicy",
-          "ecr:GetLifecyclePolicyPreview",
-          "ecr:ListTagsForResource",
-          "ecr:DescribeImageScanFindings"
-        ]
-        Resource = [
-          aws_ecr_repository.rift_env.arn
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "ecr:GetAuthorizationToken"
-        ]
-        Resource = ["*"]
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_ecr_readonly_policy.json", {
+    RIFT_ENV_ECR_REPOSITORY_ARN = aws_ecr_repository.rift_env.arn
   })
 }
 
 resource "aws_iam_policy" "rift_compute_logs" {
   name = lookup(var.resource_name_overrides, "rift_compute_logs", "tecton-rift-compute-logs")
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:ListObject",
-          "s3:HeadObject",
-          "s3:PutObject"
-        ]
-        Resource = [
-          var.s3_log_destination,
-          format("%s/*", var.s3_log_destination)
-        ]
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_compute_logs_policy.json", {
+    S3_LOG_DESTINATION = var.s3_log_destination
   })
 }
 
 resource "aws_iam_policy" "rift_bootstrap_scripts" {
   name = lookup(var.resource_name_overrides, "rift_bootstrap_scripts", "tecton-rift-boostrap-scripts")
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:ListObject",
-          "s3:HeadObject"
-        ]
-        Resource = [
-          format("%s/%s", var.offline_store_bucket_arn, "rift-bootstrap-scripts/*"),
-        ]
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_bootstrap_scripts_policy.json", {
+    OFFLINE_STORE_BUCKET_ARN = var.offline_store_bucket_arn
   })
 }
 
 resource "aws_iam_policy" "offline_store_access" {
   name = lookup(var.resource_name_overrides, "offline_store_access", "tecton-offline-store-access")
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = concat([
-      {
-        Effect = "Allow"
-        Action = ["s3:ListBucket", "s3:HeadBucket"]
-        Resource = [
-          var.offline_store_bucket_arn
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = ["s3:*"]
-        Resource = compact([
-          format("%s/%s", var.offline_store_bucket_arn, var.offline_store_key_prefix),
-          format("%s/%s*", var.offline_store_bucket_arn, var.offline_store_key_prefix),
-          format("%s/%s", var.offline_store_bucket_arn, "tecton-model-artifacts"),
-          format("%s/%s*", var.offline_store_bucket_arn, "tecton-model-artifacts")
-        ])
-      },
-      {
-        Effect   = "Allow"
-        Action   = ["s3:*"]
-        Resource = [var.offline_store_bucket_arn]
-        Condition = {
-          "StringLike" = {
-            "s3:prefix" : format("%s*", var.offline_store_key_prefix)
-          }
-        }
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:Get*",
-          "s3:List*",
-          "s3:Describe*",
-        ]
-        Resource = [
-          format("%s/%s", var.offline_store_bucket_arn, "internal/*"),
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket",
-          "s3:GetObject"
-        ]
-        Resource = ["*"]
-        # Allow access to public S3 buckets
-        Condition = {
-          "StringNotEquals" = {
-            "s3:ResourceAccount" : local.account_id
-          }
-        }
-      }],
-      local.use_kms_key ? [{
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:GenerateDataKey"
-        ]
-        Resource = [
-          var.kms_key_arn
-        ]
-      }] : [])
+  policy = templatefile("${path.module}/../templates/offline_store_access_policy.json", {
+    OFFLINE_STORE_BUCKET_ARN = var.offline_store_bucket_arn,
+    OFFLINE_STORE_KEY_PREFIX = var.offline_store_key_prefix,
+    ACCOUNT_ID               = local.account_id,
+    USE_KMS_KEY              = local.use_kms_key,
+    KMS_KEY_ARN              = var.kms_key_arn
   })
 }
 
 resource "aws_iam_policy" "rift_compute_internal" {
   name = "tecton-rift-compute-internal"
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:*"
-        ]
-        Resource = ["*"]
-        Condition = {
-          "StringEquals" = {
-            "secretsmanager:ResourceAccount" : local.account_id
-          }
-        }
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:*"
-        ]
-        Resource = ["*"]
-        Condition = {
-          "StringEquals" = {
-            "kms:ResourceAccount" : local.account_id
-          }
-        }
-      }
-    ]
+  policy = templatefile("${path.module}/../templates/rift_compute_internal_policy.json", {
+    ACCOUNT_ID = local.account_id
   })
 }
 

--- a/templates/manage_rift_compute_policy.json
+++ b/templates/manage_rift_compute_policy.json
@@ -1,0 +1,126 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StopInstances",
+        "ec2:TerminateInstances",
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:${ACCOUNT_ID}:instance/*"
+      ],
+      "Condition": {
+        "Null": {
+          "ec2:ResourceTag/tecton_rift_workflow_id": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:StartInstances",
+        "ec2:RunInstances"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:${ACCOUNT_ID}:instance/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/tecton_rift_workflow_id": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances"
+      ],
+      "Resource": ${ALLOW_RUN_INSTANCES_RESOURCES}
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:${ACCOUNT_ID}:network-interface/*"
+      ],
+      "Condition": {
+        "Null": {
+          "ec2:ResourceTag/tecton_rift_workflow_id": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:${ACCOUNT_ID}:network-interface/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/tecton_rift_workflow_id": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface"
+      ],
+      "Resource": ${ALLOW_NETWORK_INTERFACE_RESOURCES}
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*::image/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:Owner": ["amazon", "472542229217"]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iam:PassRole"],
+      "Resource": ["${RIFT_COMPUTE_ROLE_ARN}"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "servicequotas:GetServiceQuota"
+      ],
+      "Resource": [
+        "arn:aws:servicequotas:*:${ACCOUNT_ID}:ec2/L-1216C47A"
+      ]
+    }
+  ]
+} 

--- a/templates/offline_store_access_policy.json
+++ b/templates/offline_store_access_policy.json
@@ -1,0 +1,63 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:HeadBucket"],
+      "Resource": ["${OFFLINE_STORE_BUCKET_ARN}"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": [
+        "${OFFLINE_STORE_BUCKET_ARN}/${OFFLINE_STORE_KEY_PREFIX}",
+        "${OFFLINE_STORE_BUCKET_ARN}/${OFFLINE_STORE_KEY_PREFIX}*",
+        "${OFFLINE_STORE_BUCKET_ARN}/tecton-model-artifacts",
+        "${OFFLINE_STORE_BUCKET_ARN}/tecton-model-artifacts*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["${OFFLINE_STORE_BUCKET_ARN}"],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": "${OFFLINE_STORE_KEY_PREFIX}*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*",
+        "s3:Describe*"
+      ],
+      "Resource": ["${OFFLINE_STORE_BUCKET_ARN}/internal/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "StringNotEquals": {
+          "s3:ResourceAccount": "${ACCOUNT_ID}"
+        }
+      }
+    }
+    %{ if USE_KMS_KEY ~}
+    ,
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": ["${KMS_KEY_ARN}"]
+    }
+    %{ endif ~}
+  ]
+} 

--- a/templates/rift_bootstrap_scripts_policy.json
+++ b/templates/rift_bootstrap_scripts_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListObject",
+        "s3:HeadObject"
+      ],
+      "Resource": [
+        "${OFFLINE_STORE_BUCKET_ARN}/rift-bootstrap-scripts/*"
+      ]
+    }
+  ]
+} 

--- a/templates/rift_compute_internal_policy.json
+++ b/templates/rift_compute_internal_policy.json
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:*"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "StringEquals": {
+          "secretsmanager:ResourceAccount": "${ACCOUNT_ID}"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:*"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "StringEquals": {
+          "kms:ResourceAccount": "${ACCOUNT_ID}"
+        }
+      }
+    }
+  ]
+} 

--- a/templates/rift_compute_logs_policy.json
+++ b/templates/rift_compute_logs_policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListObject",
+        "s3:HeadObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${S3_LOG_DESTINATION}",
+        "${S3_LOG_DESTINATION}/*"
+      ]
+    }
+  ]
+} 

--- a/templates/rift_dynamodb_access_policy.json
+++ b/templates/rift_dynamodb_access_policy.json
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:Query"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:${ACCOUNT_ID}:table/tecton-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": ["arn:aws:iam::${ACCOUNT_ID}:role/${CLUSTER_NAME}-cross-account-intermediate"]
+    }
+  ]
+} 

--- a/templates/rift_ecr_readonly_policy.json
+++ b/templates/rift_ecr_readonly_policy.json
@@ -1,0 +1,31 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:DescribeImages",
+        "ecr:BatchGetImage",
+        "ecr:GetLifecyclePolicy",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:ListTagsForResource",
+        "ecr:DescribeImageScanFindings"
+      ],
+      "Resource": [
+        "${RIFT_ENV_ECR_REPOSITORY_ARN}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+} 

--- a/templates/rift_legacy_secrets_manager_access_policy.json
+++ b/templates/rift_legacy_secrets_manager_access_policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:*"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:*:${ACCOUNT_ID}:secret:tecton-*"
+      ]
+    }
+  ]
+} 


### PR DESCRIPTION
Moving policy definitions for the `tecton-rift-compute` and `tecton-rift-compute-manager` roles out of HCL and into json templates in the `templates/` directory. Tested by using git source reference to this (`templates-iam`) branch and running `terraform plan` on an internal cluster state that uses the `rift_compute` module. Result = "No changes. Your infrastructure matches the configuration."

