### PR TITLE
fix: Give issues(labelling) permission to release-please action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `release-please` action successfully created PR on the last merge, but failed to add labels ([log](https://github.com/tecton-ai/tecton-terraform-setup/actions/runs/15196344021/job/42741265126)). Following the guidance from [this issue](https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2780292262) to add appropriate permission.