### PR TITLE
feat: Add options for disabling direct cross-account bucket policy and limiting cross-account assumerole

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -14,6 +14,7 @@
 | <a name="input_additional_s3_read_only_principals"></a> [additional\_s3\_read\_only\_principals](#input\_additional\_s3\_read\_only\_principals) | n/a | `list(string)` | `[]` | no |
 | <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | Server-side encryption algorithm to use. Valid values are AES256 and aws:kms.<br/> Note: (1) All resources should also be granted permission to decrypt with the KMS key if using KMS.<br/>       (2) If athena retrieval is used, the kms\_key option must also be set on the athena session. | `string` | `"AES256"` | no |
 | <a name="input_bucket_sse_key_enabled"></a> [bucket\_sse\_key\_enabled](#input\_bucket\_sse\_key\_enabled) | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `null` | no |
+| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `false` | no |
 | <a name="input_create_emr_roles"></a> [create\_emr\_roles](#input\_create\_emr\_roles) | Whether to create EMR roles. | `bool` | `false` | no |
 | <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | External ID for cross-account role assumption. | `string` | n/a | yes |
 | <a name="input_cross_account_role_allow_sts_metadata"></a> [cross\_account\_role\_allow\_sts\_metadata](#input\_cross\_account\_role\_allow\_sts\_metadata) | Enable sts:SetSourceIdentity and sts:TagSession permissions on the cross-role account. | `bool` | `false` | no |
@@ -21,6 +22,7 @@
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the Tecton deployment. | `string` | n/a | yes |
 | <a name="input_emr_read_ecr_repositories"></a> [emr\_read\_ecr\_repositories](#input\_emr\_read\_ecr\_repositories) | List of ECR repositories that EMR roles are granted read access to. | `list(string)` | `[]` | no |
 | <a name="input_emr_spark_role_name"></a> [emr\_spark\_role\_name](#input\_emr\_spark\_role\_name) | Override the default name Tecton uses for emr spark role | `string` | `null` | no |
+| <a name="input_include_crossaccount_bucket_access"></a> [include\_crossaccount\_bucket\_access](#input\_include\_crossaccount\_bucket\_access) | Whether to grant direct cross-account bucket access | `bool` | `true` | no |
 | <a name="input_kms_key_additional_principals"></a> [kms\_key\_additional\_principals](#input\_kms\_key\_additional\_principals) | Additional set of principals to grant KMS key access to | `list(string)` | `[]` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | If provided, the ID of customer-managed key for encrypting data at rest | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region (of Tecton control plane _and_ data plane account). | `string` | n/a | yes |

--- a/deployment/buckets.tf
+++ b/deployment/buckets.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_public_access_block" "tecton" {
 
 
 locals {
-  enable_s3_bucket_policy = (length(var.additional_s3_read_only_principals) > 0 || length(var.s3_read_write_principals) > 0)
+  enable_s3_bucket_policy = (length(var.additional_s3_read_only_principals) > 0 || length(var.s3_read_write_principals) > 0) && var.include_crossaccount_bucket_access
 }
 
 data "aws_iam_policy_document" "s3_bucket_policy" {

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -119,3 +119,15 @@ variable "cross_account_role_allow_sts_metadata" {
   description = "Enable sts:SetSourceIdentity and sts:TagSession permissions on the cross-role account."
   default     = false
 }
+
+variable "controlplane_access_only" {
+  type        = bool
+  description = "Whether to only grant control-plane account access to the cross-account role"
+  default     = false
+}
+
+variable "include_crossaccount_bucket_access" {
+  type        = bool
+  description = "Whether to grant direct cross-account bucket access"
+  default     = true
+}

--- a/modules/dataplane_rift/README.md
+++ b/modules/dataplane_rift/README.md
@@ -33,13 +33,15 @@ module "tecton" {
     aws = aws
   }
 
-  deployment_name                 = "deployment-name" # Replace with the deployment name agreed with Tecton
-  region                          = "us-west-2" # Replace with the region your account/Tecton deployment will use
-  account_id                      = "123456789012" # Your AWS Account ID
-  subnet_azs                      = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  tecton_control_plane_account_id = "987654321098" # Tecton's Control Plane Account ID
-  cross_account_external_id       = "your-external-id"    # External ID from Tecton
-  tecton_control_plane_role_name  = "TectonControlPlaneRole" # Role name from Tecton
+  deployment_name                    = "deployment-name" # Replace with the deployment name agreed with Tecton
+  region                             = "us-west-2" # Replace with the region your account/Tecton deployment will use
+  account_id                         = "123456789012" # Your AWS Account ID
+  subnet_azs                         = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  tecton_control_plane_account_id    = "987654321098" # Tecton's Control Plane Account ID
+  cross_account_external_id          = "your-external-id"    # External ID from Tecton
+  tecton_control_plane_role_name     = "TectonControlPlaneRole" # Role name from Tecton
+  controlplane_access_only           = true
+  include_crossaccount_bucket_access = false
 
   # Optional: For PrivateLink to Control Plane. Add _after_ deployment is complete and PrivateLink details are shared by Tecton
   # tecton_vpce_service_name = "com.amazonaws.vpce.us-west-2.vpce-svc-xxxxxxxxxxxxxxxxx"
@@ -70,10 +72,12 @@ output "tecton" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
 | <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. Only works if using VPC managed by this module (i.e. existing\_vpc is not provided). | `list(string)` | `null` | no |
+| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `false` | no |
 | <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
 | <a name="input_existing_rift_compute_security_group_id"></a> [existing\_rift\_compute\_security\_group\_id](#input\_existing\_rift\_compute\_security\_group\_id) | (Optional) The ID of the existing security group to use for Rift compute instances. | `string` | `null` | no |
 | <a name="input_existing_vpc"></a> [existing\_vpc](#input\_existing\_vpc) | (Optional) Configuration for using an existing VPC. If provided, both vpc\_id and private\_subnet\_ids must be provided together. | <pre>object({<br/>    vpc_id               = string<br/>    private_subnet_ids   = list(string)<br/>  })</pre> | `null` | no |
+| <a name="input_include_crossaccount_bucket_access"></a> [include\_crossaccount\_bucket\_access](#input\_include\_crossaccount\_bucket\_access) | Whether to grant direct cross-account bucket access | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region for the Tecton deployment. | `string` | n/a | yes |
 | <a name="input_subnet_azs"></a> [subnet\_azs](#input\_subnet\_azs) | A list of Availability Zones for the subnets. | `list(string)` | n/a | yes |

--- a/modules/dataplane_rift/README.md
+++ b/modules/dataplane_rift/README.md
@@ -40,7 +40,6 @@ module "tecton" {
   tecton_control_plane_account_id    = "987654321098" # Tecton's Control Plane Account ID
   cross_account_external_id          = "your-external-id"    # External ID from Tecton
   tecton_control_plane_role_name     = "TectonControlPlaneRole" # Role name from Tecton
-  controlplane_access_only           = true
   include_crossaccount_bucket_access = false
 
   # Optional: For PrivateLink to Control Plane. Add _after_ deployment is complete and PrivateLink details are shared by Tecton
@@ -72,7 +71,7 @@ output "tecton" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
 | <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. Only works if using VPC managed by this module (i.e. existing\_vpc is not provided). | `list(string)` | `null` | no |
-| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `false` | no |
+| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `true` | no |
 | <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
 | <a name="input_existing_rift_compute_security_group_id"></a> [existing\_rift\_compute\_security\_group\_id](#input\_existing\_rift\_compute\_security\_group\_id) | (Optional) The ID of the existing security group to use for Rift compute instances. | `string` | `null` | no |

--- a/modules/dataplane_rift/infrastructure.tf
+++ b/modules/dataplane_rift/infrastructure.tf
@@ -19,10 +19,12 @@ module "tecton" {
   tecton_assuming_account_id = var.tecton_control_plane_account_id
 
   # Control plane root principal
-  s3_read_write_principals          = [format("arn:aws:iam::%s:root", var.tecton_control_plane_account_id)]
-  use_spark_compute                 = false
-  use_rift_cross_account_policy     = true
-  kms_key_id                        = var.kms_key_id
+  s3_read_write_principals           = [format("arn:aws:iam::%s:root", var.tecton_control_plane_account_id)]
+  use_spark_compute                  = false
+  use_rift_cross_account_policy      = true
+  kms_key_id                         = var.kms_key_id
+  controlplane_access_only           = var.controlplane_access_only
+  include_crossaccount_bucket_access = var.include_crossaccount_bucket_access
 }
 
 

--- a/modules/dataplane_rift/variables.tf
+++ b/modules/dataplane_rift/variables.tf
@@ -42,7 +42,7 @@ variable "tecton_control_plane_role_name" {
 variable "controlplane_access_only" {
   description = "Whether to only grant control-plane account access to the cross-account role"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "include_crossaccount_bucket_access" {

--- a/modules/dataplane_rift/variables.tf
+++ b/modules/dataplane_rift/variables.tf
@@ -39,6 +39,18 @@ variable "tecton_control_plane_role_name" {
   type        = string
 }
 
+variable "controlplane_access_only" {
+  description = "Whether to only grant control-plane account access to the cross-account role"
+  type        = bool
+  default     = false
+}
+
+variable "include_crossaccount_bucket_access" {
+  description = "Whether to grant direct cross-account bucket access"
+  type        = bool
+  default     = true
+}
+
 variable "existing_vpc" {
   description = "(Optional) Configuration for using an existing VPC. If provided, both vpc_id and private_subnet_ids must be provided together."
   type = object({

--- a/modules/dataplane_rift_with_emr/README.md
+++ b/modules/dataplane_rift_with_emr/README.md
@@ -31,13 +31,15 @@ module "tecton" {
     aws = aws
   }
 
-  deployment_name                 = "my-tecton-deployment" # Replace with the deployment name agreed with Tecton
-  region                          = "us-west-2" # Replace with the region your account/Tecton deployment will use
-  account_id                      = "123456789012"     # Replace with your AWS Account ID
-  subnet_azs                      = ["us-west-2a", "us-west-2b", "us-west-2c"]  # Replace with AZs in the region of your choice
-  tecton_control_plane_account_id = "987654321098"     # Replace with Tecton's Control Plane Account ID
-  cross_account_external_id       = "your-external-id" # Replace with the External ID from Tecton
-  tecton_control_plane_role_name  = "TectonControlPlaneRole" # Role name from Tecton
+  deployment_name                    = "my-tecton-deployment" # Replace with the deployment name agreed with Tecton
+  region                             = "us-west-2" # Replace with the region your account/Tecton deployment will use
+  account_id                         = "123456789012"     # Replace with your AWS Account ID
+  subnet_azs                         = ["us-west-2a", "us-west-2b", "us-west-2c"]  # Replace with AZs in the region of your choice
+  tecton_control_plane_account_id    = "987654321098"     # Replace with Tecton's Control Plane Account ID
+  cross_account_external_id          = "your-external-id" # Replace with the External ID from Tecton
+  tecton_control_plane_role_name     = "TectonControlPlaneRole" # Role name from Tecton
+  controlplane_access_only           = true
+  include_crossaccount_bucket_access = false
 
   # (OPTIONAL)
   # To enable the EMR notebook cluster (Only uncomment all lines below _after_ you have already applied once and control plane deployment is complete):
@@ -85,11 +87,13 @@ This module provisions:
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
 | <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. Only works if using VPC managed by this module (i.e. existing\_vpc is not provided). | `list(string)` | `null` | no |
+| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `false` | no |
 | <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
 | <a name="input_emr_debugging_count"></a> [emr\_debugging\_count](#input\_emr\_debugging\_count) | Set to 1 to allow Tecton to debug EMR clusters. Set to 0 to disable. Requires Tecton deployment. | `number` | `0` | no |
 | <a name="input_existing_rift_compute_security_group_id"></a> [existing\_rift\_compute\_security\_group\_id](#input\_existing\_rift\_compute\_security\_group\_id) | (Optional) The ID of the existing security group to use for Rift compute instances. | `string` | `null` | no |
 | <a name="input_existing_vpc"></a> [existing\_vpc](#input\_existing\_vpc) | (Optional) Configuration for using an existing VPC. If provided, both vpc\_id and private\_subnet\_ids must be provided together. | <pre>object({<br/>    vpc_id               = string<br/>    private_subnet_ids   = list(string)<br/>  })</pre> | `null` | no |
+| <a name="input_include_crossaccount_bucket_access"></a> [include\_crossaccount\_bucket\_access](#input\_include\_crossaccount\_bucket\_access) | Whether to grant direct cross-account bucket access | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The customer-managed key for encrypting data at rest. | `string` | `null` | no |
 | <a name="input_notebook_cluster_count"></a> [notebook\_cluster\_count](#input\_notebook\_cluster\_count) | Set to 1 to create the EMR notebook cluster. Set to 0 to disable. Requires Tecton deployment to be confirmed by your Tecton rep. | `number` | `0` | no |
 | <a name="input_notebook_extra_bootstrap_actions"></a> [notebook\_extra\_bootstrap\_actions](#input\_notebook\_extra\_bootstrap\_actions) | (Optional) List of extra bootstrap actions for the EMR notebook cluster. | <pre>list(object({<br/>    name = string<br/>    path = string<br/>  }))</pre> | `null` | no |

--- a/modules/dataplane_rift_with_emr/README.md
+++ b/modules/dataplane_rift_with_emr/README.md
@@ -38,7 +38,6 @@ module "tecton" {
   tecton_control_plane_account_id    = "987654321098"     # Replace with Tecton's Control Plane Account ID
   cross_account_external_id          = "your-external-id" # Replace with the External ID from Tecton
   tecton_control_plane_role_name     = "TectonControlPlaneRole" # Role name from Tecton
-  controlplane_access_only           = true
   include_crossaccount_bucket_access = false
 
   # (OPTIONAL)
@@ -87,7 +86,7 @@ This module provisions:
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID where Tecton will be deployed. | `string` | n/a | yes |
 | <a name="input_additional_allowed_egress_domains"></a> [additional\_allowed\_egress\_domains](#input\_additional\_allowed\_egress\_domains) | (Optional) List of additional domains to allow for egress if use\_network\_firewall is true. Only works if using VPC managed by this module (i.e. existing\_vpc is not provided). | `list(string)` | `null` | no |
-| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `false` | no |
+| <a name="input_controlplane_access_only"></a> [controlplane\_access\_only](#input\_controlplane\_access\_only) | Whether to only grant control-plane account access to the cross-account role | `bool` | `true` | no |
 | <a name="input_cross_account_external_id"></a> [cross\_account\_external\_id](#input\_cross\_account\_external\_id) | The external ID for cross-account access. Obtain this from your Tecton representative. | `string` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the Tecton deployment. Must be less than 22 characters due to AWS limitations. | `string` | n/a | yes |
 | <a name="input_emr_debugging_count"></a> [emr\_debugging\_count](#input\_emr\_debugging\_count) | Set to 1 to allow Tecton to debug EMR clusters. Set to 0 to disable. Requires Tecton deployment. | `number` | `0` | no |

--- a/modules/dataplane_rift_with_emr/infrastructure.tf
+++ b/modules/dataplane_rift_with_emr/infrastructure.tf
@@ -19,11 +19,13 @@ module "tecton" {
   tecton_assuming_account_id = var.tecton_control_plane_account_id
 
   # Control plane root principal
-  s3_read_write_principals          = [format("arn:aws:iam::%s:root", var.tecton_control_plane_account_id)]
-  use_spark_compute                 = true
-  use_rift_cross_account_policy     = true
-  kms_key_id                        = var.kms_key_id
-  create_emr_roles                  = true
+  s3_read_write_principals           = [format("arn:aws:iam::%s:root", var.tecton_control_plane_account_id)]
+  use_spark_compute                  = true
+  use_rift_cross_account_policy      = true
+  kms_key_id                         = var.kms_key_id
+  create_emr_roles                   = true
+  controlplane_access_only           = var.controlplane_access_only
+  include_crossaccount_bucket_access = var.include_crossaccount_bucket_access
 }
 
 module "rift" {

--- a/modules/dataplane_rift_with_emr/variables.tf
+++ b/modules/dataplane_rift_with_emr/variables.tf
@@ -54,6 +54,18 @@ variable "tecton_control_plane_role_name" {
   type        = string
 }
 
+variable "controlplane_access_only" {
+  description = "Whether to only grant control-plane account access to the cross-account role"
+  type        = bool
+  default     = false
+}
+
+variable "include_crossaccount_bucket_access" {
+  description = "Whether to grant direct cross-account bucket access"
+  type        = bool
+  default     = true
+}
+
 variable "tecton_vpce_service_name" {
   description = "(Optional) The VPC endpoint service name for Tecton. Only needed if using PrivateLink."
   type        = string

--- a/modules/dataplane_rift_with_emr/variables.tf
+++ b/modules/dataplane_rift_with_emr/variables.tf
@@ -57,7 +57,7 @@ variable "tecton_control_plane_role_name" {
 variable "controlplane_access_only" {
   description = "Whether to only grant control-plane account access to the cross-account role"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "include_crossaccount_bucket_access" {


### PR DESCRIPTION
Adding two options to `rift_compute` module: 
1. `controlplane_access_only` -- When `true`, this removes legacy `153453085158` account from trust policy for cross-account role. This works for all newer accounts that only rely on access from roles in the control-plane account directly.
2. `include_crossaccount_bucket_access` -- When `true`, does _not_ add bucket policy to offline-store bucket for direct cross-account access. This is OK for dataplane Rift, where all access to the offline-store will come through the assumed role in dataplane. [Reference](https://tectonworkspace.slack.com/archives/C08D8QRLEEP/p1745257752620189?thread_ts=1745255476.126599&cid=C08D8QRLEEP)

Setting defaults for both of these appropriately in `dataplane_rift` and `dataplane_rift_with_emr` module. Control plane rift/existing direct users of `deployment` module won't see a change, this only affects the 'new' `modules/` users and will be default going forward.


Tested with internal state, results in this type of change:
```hcl
  # module.tecton.aws_iam_role.cross_account_role will be updated in-place
  ~ resource "aws_iam_role" "cross_account_role" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ AWS = [
                              - "arn:aws:iam::<CTRL_PLANE_ACCOUNT_ID>:root",
                              - "arn:aws:iam::153453085158:root",
                            ] -> "arn:aws:iam::<CTRL_PLANE_ACCOUNT_ID>:root"
                        }
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "<ACCOUNT>-cross-account-role"
        name                  = "<ACCOUNT>-cross-account-role"
        tags                  = {
            "tecton-accessible:<ACCOUNT>" = "true"
        }
        # (9 unchanged attributes hidden)
    }

  # module.tecton.aws_s3_bucket_policy.tecton[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_s3_bucket_policy" "tecton" {
      - bucket = "<BUCKET>" -> null
      - id     = "<BUCKET>" -> null
      - policy = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "s3:ListBucket"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "arn:aws:iam::<ACCOUNT_ID>:root"
                        }
                      - Resource  = "arn:aws:s3:::<BUCKET>"
                      - Sid       = "S3Bucket"
                    },
                  - {
                      - Action    = [
                          - "s3:PutObject",
                          - "s3:GetObject",
                          - "s3:DeleteObject",
                        ]
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "arn:aws:iam::<ACCOUNT_ID>:root"
                        }
                      - Resource  = "arn:aws:s3:::<BUCKET>/*"
                      - Sid       = "S3Object"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
    }
```