### PR TITLE
Add ecr:GetAuthorizationToken to permitted actions

### DIFF
--- a/deployment/roles.tf
+++ b/deployment/roles.tf
@@ -80,6 +80,7 @@ data "aws_iam_policy_document" "cross_account_role_ecr" {
     actions = [
       "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
+      "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
       "ecr:UploadLayerPart",

--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -35,6 +35,7 @@ data "aws_iam_policy_document" "cross_account_ecr" {
     actions = [
       "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
+      "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
       "ecr:UploadLayerPart",


### PR DESCRIPTION
When we enabled use of cross-account-ecr on dev rift, it failed due to unavailability of ecr:GetAuthorizationToken. This PR allow-lists that action.

ref FOUND-484