### PR TITLE
Permit cross-account role to perform BatchGetImage

### DIFF
--- a/rift_compute/main.tf
+++ b/rift_compute/main.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "cross_account_ecr" {
 
     actions = [
       "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
       "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",


### PR DESCRIPTION
Per [this discussion](https://tectonworkspace.slack.com/archives/C08CYPHGFSR/p1753214433422619?thread_ts=1753212924.694069&cid=C08CYPHGFSR), we believe that we need to allow the cross-account dataplane role to perform BatchGetImage. This is because Rift pulls the base image from tecton-staging (hence the BatchGetImage call).

ref FOUND-484
cc: @sethnelson-tecton 