### PR TITLE
fix: Only create fargate satellite policy if fargate_enabled.

### DIFF
--- a/roles/satellite.tf
+++ b/roles/satellite.tf
@@ -264,7 +264,7 @@ resource "aws_iam_role_policy_attachment" "satellite_devops" {
 
 # Fargate satellite [Common : Databricks and EMR]
 resource "aws_iam_policy" "eks_fargate_satellite_node" {
-  for_each = toset(var.satellite_regions)
+  for_each = var.fargate_enabled ? toset(var.satellite_regions) : toset([])
 
   name = "tecton-${var.deployment_name}-${each.value}-eks-fargate-node"
   policy = templatefile("${path.module}/../templates/fargate_eks_role.json",


### PR DESCRIPTION
This `eks_fargate_satellite_node` IAM policy is only used for fargate. Placing it behind the existing `fargate_enabled` flag so that it doesn't get unnecessarily created.