### PR TITLE
fix: Add ARN output for emr-master-role.

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -38,6 +38,7 @@
 |------|-------------|
 | <a name="output_cross_account_role_arn"></a> [cross\_account\_role\_arn](#output\_cross\_account\_role\_arn) | ARN of the cross-account role Tecton control-plane will assume in your account. |
 | <a name="output_cross_account_role_name"></a> [cross\_account\_role\_name](#output\_cross\_account\_role\_name) | Name of cross-account role Tecton control-plane will assume in your account. |
+| <a name="output_emr_master_role_arn"></a> [emr\_master\_role\_arn](#output\_emr\_master\_role\_arn) | *(Only included if create\_emr\_roles is true)* ARN of the EMR master role. |
 | <a name="output_emr_master_role_name"></a> [emr\_master\_role\_name](#output\_emr\_master\_role\_name) | *(Only included if create\_emr\_roles is true)* Name of the EMR master role. |
 | <a name="output_emr_spark_instance_profile_arn"></a> [emr\_spark\_instance\_profile\_arn](#output\_emr\_spark\_instance\_profile\_arn) | *(Only included if create\_emr\_roles is true)* ARN of the EMR Spark instance profile. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used to encrypt the Tecton S3 bucket. |

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -23,6 +23,11 @@ output "emr_master_role_name" {
   value = var.create_emr_roles ? aws_iam_role.emr_master_role[0].name : null
 }
 
+output "emr_master_role_arn" {
+  description = "*(Only included if create_emr_roles is true)* ARN of the EMR master role."
+  value = var.create_emr_roles ? aws_iam_role.emr_master_role[0].arn : null
+}
+
 output "emr_spark_instance_profile_arn" {
   description = "*(Only included if create_emr_roles is true)* ARN of the EMR Spark instance profile."
   value = var.create_emr_roles ? aws_iam_instance_profile.emr_spark_instance_profile[0].arn : null


### PR DESCRIPTION
The EMR wrapper modules (`controlplane_rift_with_emr`, `emr`) currently reference a non-existent output when writing to the shared bucket/location, which causes this issue in TF plan.:
```sh
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/tecton/modules/controlplane_rift_with_emr/infrastructure.tf line 123, in module "tecton_outputs":
│  123:     emr_master_role_arn                 = module.tecton.emr_master_role_arn
│     ├────────────────
│     │ module.tecton is a object
│ 
│ This object does not have an attribute named "emr_master_role_arn".
```

Fixing by adding the expected output (previously only the name was there, adding ARN too).



Tested by updating an internal cluster to reference this branch -- no longer see the error in plan.