### PR TITLE
Fix condition on rift-compute-internal-policy

### DIFF
--- a/templates/rift_compute_internal_policy.json
+++ b/templates/rift_compute_internal_policy.json
@@ -9,7 +9,7 @@
       "Resource": ["*"],
       "Condition": {
         "StringEquals": {
-          "secretsmanager:ResourceAccount": "${ACCOUNT_ID}"
+          "aws:ResourceAccount": "${ACCOUNT_ID}"
         }
       }
     },
@@ -21,7 +21,7 @@
       "Resource": ["*"],
       "Condition": {
         "StringEquals": {
-          "kms:ResourceAccount": "${ACCOUNT_ID}"
+          "aws:ResourceAccount": "${ACCOUNT_ID}"
         }
       }
     }


### PR DESCRIPTION
the condition keys provided were invalid and instead should use the global condition key aws:ResourceAccount

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-resource-properties