### PR TITLE
Introduce Conditional Naming for IAM Policy in Shared AWS Accounts

### DIFF
--- a/roles/satellite.tf
+++ b/roles/satellite.tf
@@ -240,7 +240,7 @@ resource "aws_iam_policy" "s3_batch_replication" {
 # EKS [Common : Databricks and EMR]
 resource "aws_iam_policy" "satellite_ca" {
   count = local.is_satellite_regions_enabled ? 1 : 0
-  name  = "tecton-satellite-ca-policy"
+  name  = var.is_shared_account ? "tecton-${var.deployment_name}-satellite-ca-policy" : "tecton-satellite-ca-policy"
   policy = templatefile("${path.module}/../templates/satellite_ca_policy.json",
     {
       ACCOUNT_ID      = var.account_id

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -158,3 +158,9 @@ variable "satellite_region_short_codes_enabled" {
   type        = bool
   default     = false
 }
+
+variable "shared_account" {
+  description = "If true, ensure unique names exist in a single AWS account"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This pull request introduces a new Terraform variable, `shared_account`, and uses it to conditionally generate a unique name for the `aws_iam_policy.satellite_ca` resource.

This change is essential for supporting deployments in **shared AWS accounts** where multiple instances of the infrastructure may exist within the same account.

### Why is this change necessary?

The `aws_iam_policy.satellite_ca` resource is conditionally created based on `local.is_satellite_regions_enabled` (i.e., it is a single instance, not iterated per region). Without a deployment-specific prefix, multiple parallel deployments using this module in a single AWS account would lead to a Terraform state conflict because the IAM policy names would clash.

### Key Changes

1.  **New Input Variable (`roles/variables.tf`):**
    A new boolean variable, `shared_account`, has been added.

      * `default = false` (Maintains backward compatibility).
      * When set to `true`, it signals that resource naming must be unique within the AWS account.

2.  **Conditional Naming Logic (`roles/satellite.tf`):**
    The `name` attribute for `aws_iam_policy.satellite_ca` is updated to include `var.deployment_name` when `var.shared_account` is true.

      * **Old Name:** `tecton-satellite-ca-policy`
      * **New Conditional Name:**
        ```terraform
        name = var.shared_account ? "tecton-${var.deployment_name}-satellite-ca-policy" : "tecton-satellite-ca-policy"
        ```

### Action Required by User

If deploying this infrastructure into an AWS account that is shared with other deployments of this service, the user **must** set `shared_account = true` in their configuration.