### PR TITLE
Fix EKS Node Group IAM policy to support cluster-tagged Security Groups

### DIFF
--- a/templates/devops_eks_policy.json
+++ b/templates/devops_eks_policy.json
@@ -132,6 +132,21 @@
             }
         },
         {
+            "Sid": "AllowAttachedSecurityGroups",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group/*"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "aws:ResourceTag/tecton-cluster-name": "${DEPLOYMENT_NAME}*"
+                }
+            }
+        },
+        {
             "Sid": "CreateWithTaggedInstance",
             "Effect": "Allow",
             "Action": [


### PR DESCRIPTION
Add IAM policy statement to allow ec2:RunInstances on Security Groups tagged with tecton-cluster-name. This resolves UnauthorizedOperation errors during EKS Node Group updates when Security Groups use the cluster name tag instead of the tecton-accessible tag.