### PR TITLE
Optimize the satellite policy json

### DIFF
--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -6,25 +6,7 @@ locals {
     var.account_id,
     var.deployment_name
   )
-  all_regions                    = concat(var.satellite_regions, [var.region])
-  satellite_feature_server_roles = concat(formatlist("arn:aws:iam::%s:role/tecton-%s-%s-fargate-fs", var.account_id, var.deployment_name, var.satellite_regions), formatlist("arn:aws:iam::%s:role/%s-%s-fargate-fs", var.account_id, var.deployment_name, var.satellite_regions))
-  satellite_kinesis_firehose_roles = formatlist("arn:aws:iam::%s:role/%s-%s_fargate_kinesis_firehose", var.account_id, var.deployment_name, var.satellite_regions)
-  satellite_fargate_cross_account_policies = formatlist("arn:aws:iam::%s:policy/%s-%s-fargate-cross-account-write", var.account_id, var.deployment_name, var.satellite_regions)
-  feature_server_roles = concat(
-    [format("arn:aws:iam::%s:role/tecton-%s-fargate-fs", var.account_id, var.deployment_name)],
-    local.satellite_feature_server_roles,
-    [format("arn:aws:iam::%s:role/%s-fargate-fs", var.account_id, var.deployment_name)],
-  )
-  fargate_aws_managed_policies = [
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
-  ]
-  feature_server_policies = concat(
-    [aws_iam_policy.eks_fargate_node_policy[0].arn],
-    [for region in var.satellite_regions : aws_iam_policy.eks_fargate_satellite_node[region].arn],
-    local.fargate_aws_managed_policies
-  )
+  all_regions = concat(var.satellite_regions, [var.region])
   data_validation_worker_roles = var.data_validation_on_fargate_enabled ? [
     format("arn:aws:iam::%s:role/tecton-%s-fargate-validation", var.account_id, var.deployment_name)
   ] : []
@@ -115,21 +97,6 @@ resource "aws_iam_policy" "devops_fargate_policy" {
     {
       ACCOUNT_ID      = var.account_id
       DEPLOYMENT_NAME = var.deployment_name
-      FARGATE_ROLES = jsonencode(
-        concat(
-          local.feature_server_roles,
-          local.data_validation_worker_roles,
-          local.satellite_kinesis_firehose_roles
-        )
-      )
-      FARGATE_POLICY_ARNS = jsonencode(
-        concat(
-          local.feature_server_policies,
-          local.data_validation_worker_policies,
-          local.satellite_fargate_cross_account_policies
-        )
-      )
-      SATELLITE_FARGATE_POLICIES = jsonencode(local.satellite_fargate_cross_account_policies)
     }
   )
   tags = local.tags

--- a/templates/devops_fargate.json
+++ b/templates/devops_fargate.json
@@ -11,10 +11,22 @@
                 "iam:DetachRolePolicy",
                 "iam:DeleteRolePolicy"
             ],
-            "Resource": ${FARGATE_ROLES},
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*_fargate_*"
+            ],
             "Condition": {
-                "StringEquals": {
-                    "iam:PolicyARN": ${FARGATE_POLICY_ARNS}
+                "StringLike": {
+                    "iam:PolicyARN": [
+                        "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-${DEPLOYMENT_NAME}-*",
+                        "arn:aws:iam::${ACCOUNT_ID}:policy/${DEPLOYMENT_NAME}-*",
+                        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+                        "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+                        "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+                    ]
                 }
             }
         },
@@ -30,7 +42,13 @@
                 "iam:DeleteRole",
                 "iam:UpdateAssumeRolePolicy"
             ],
-            "Resource": ${FARGATE_ROLES}
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*_fargate_*"
+            ]
         },
         {
             "Sid": "FargateListRole",
@@ -121,9 +139,15 @@
                 "iam:GetPolicyVersion",
                 "iam:ListPolicyVersions",
                 "iam:CreatePolicyVersion",
-                "iam:DeletePolicyVersion"
+                "iam:DeletePolicyVersion",
+                "iam:TagPolicy"
             ],
-            "Resource": ${SATELLITE_FARGATE_POLICIES}
+            "Resource": [
+                "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:policy/${DEPLOYMENT_NAME}-*-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-${DEPLOYMENT_NAME}-fargate-*",
+                "arn:aws:iam::${ACCOUNT_ID}:policy/${DEPLOYMENT_NAME}-fargate-*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
templates/devops_fargate.json was transformed from using explicit role/policy lists to wildcard patterns:

  Before:
  - Built explicit lists in roles/roles.tf for every satellite region
  - Used `jsonencode()` to pass lists like ${FARGATE_ROLES}, ${FARGATE_POLICY_ARNS}
  - Used StringEquals with exact ARN matching

  After:
  - Removed all the list-building code from roles.tf (35 lines removed)
  - Replaced with wildcard patterns in the template:
```
  "Resource": [
    "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-*-fargate-*",
    "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*-fargate-*",
    "arn:aws:iam::${ACCOUNT_ID}:role/tecton-${DEPLOYMENT_NAME}-fargate-*",
    "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-fargate-*",
    "arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-*_fargate_*"
  ]
```
  - Changed to StringLike for pattern matching
  - Added AWS managed policy ARNs directly in the template