### PR TITLE
Add additional_deployment_names variable

### DIFF
--- a/emr_sample/infrastructure.tf
+++ b/emr_sample/infrastructure.tf
@@ -155,6 +155,12 @@ variable "enable_custom_environments" {
   description = "Whether to enable creation of custom environments. This will create an ecr repo to store environments, and allow eks nodes to store images in that that repo. Default: false."
 }
 
+variable "additional_deployment_names" {
+  type        = list(string)
+  description = "Additional deployment name prefixes to grant the devops role access to (e.g., legacy deployment names)."
+  default     = []
+}
+
 variable "eks_vpc_enable_dns_hostnames" {
   type        = bool
   description = "Whether or not the VPC has DNS hostname support"
@@ -251,6 +257,7 @@ module "roles" {
   offline_store_key_prefix                         = var.offline_store_key_prefix
   offline_store_cmk_arns                           = var.offline_store_cmk_arns
   enable_custom_environments                       = var.enable_custom_environments
+  additional_deployment_names                      = var.additional_deployment_names
 }
 
 module "notebook_cluster" {

--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -13,15 +13,31 @@ locals {
   data_validation_worker_policies = var.data_validation_on_fargate_enabled ? [
     aws_iam_policy.eks_fargate_data_validation_worker[0].arn
   ] : []
+  all_deployment_names = concat([var.deployment_name], var.additional_deployment_names)
   s3_buckets = concat(
     formatlist("arn:aws:s3:::tecton-%s-%s", var.deployment_name, var.satellite_regions),
     ["arn:aws:s3:::tecton-${var.deployment_name}"],
+    flatten([for name in var.additional_deployment_names : concat(
+      formatlist("arn:aws:s3:::tecton-%s-%s", name, var.satellite_regions),
+      ["arn:aws:s3:::tecton-${name}"],
+      ["arn:aws:s3:::${name}-*"],
+    )]),
     var.additional_s3_buckets,
   )
   s3_objects                  = formatlist("%s/*", local.s3_buckets)
   data_validation_enabled     = var.fargate_enabled && var.data_validation_on_fargate_enabled
   enable_offline_store_reader = var.enable_rift
   dynamodb_table_pattern      = var.dynamodb_table_pattern != null ? var.dynamodb_table_pattern : format("tecton-%s*", var.deployment_name)
+  instance_profile_manage_resources = concat(
+    [
+      "arn:aws:iam::${var.account_id}:policy/tecton-*",
+      "arn:aws:iam::${var.account_id}:role/tecton-*",
+      "arn:aws:iam::${var.account_id}:instance-profile/tecton-*",
+    ],
+    formatlist("arn:aws:iam::%s:instance-profile/%s-worker-node", var.account_id, local.all_deployment_names),
+    formatlist("arn:aws:iam::%s:instance-profile/%s-spark-node", var.account_id, local.all_deployment_names),
+  )
+  secret_resources = formatlist("arn:aws:secretsmanager:*:*:secret:tecton-%s/*", local.all_deployment_names)
 
 }
 
@@ -231,11 +247,12 @@ resource "aws_iam_policy" "devops_policy_1" {
   policy = templatefile(
     "${path.module}/../templates/devops_policy_1.json",
     {
-      ACCOUNT_ID             = var.account_id
-      DEPLOYMENT_NAME        = var.deployment_name
-      DEPLOYMENT_NAME_CONCAT = format("%.24s", "tecton-${var.deployment_name}")
-      S3_BUCKETS             = jsonencode(local.s3_buckets)
-      S3_OBJECTS             = jsonencode(local.s3_objects)
+      ACCOUNT_ID                        = var.account_id
+      DEPLOYMENT_NAME                   = var.deployment_name
+      DEPLOYMENT_NAME_CONCAT            = format("%.24s", "tecton-${var.deployment_name}")
+      S3_BUCKETS                        = jsonencode(local.s3_buckets)
+      S3_OBJECTS                        = jsonencode(local.s3_objects)
+      INSTANCE_PROFILE_MANAGE_RESOURCES = jsonencode(local.instance_profile_manage_resources)
     }
   )
   tags = local.tags
@@ -247,8 +264,9 @@ resource "aws_iam_policy" "devops_policy_2" {
   policy = templatefile(
     "${path.module}/../templates/devops_policy_2.json",
     {
-      ACCOUNT_ID      = var.account_id
-      DEPLOYMENT_NAME = var.deployment_name
+      ACCOUNT_ID       = var.account_id
+      DEPLOYMENT_NAME  = var.deployment_name
+      SECRET_RESOURCES = jsonencode(local.secret_resources)
     }
   )
   tags = local.tags

--- a/roles/variables.tf
+++ b/roles/variables.tf
@@ -147,6 +147,12 @@ variable "additional_s3_buckets" {
   default     = []
 }
 
+variable "additional_deployment_names" {
+  type        = list(string)
+  description = "Additional deployment name prefixes to grant the devops role access to (e.g., legacy deployment names)."
+  default     = []
+}
+
 variable "dynamodb_table_pattern" {
   type        = string
   description = "Defines a pattern that identifies which DynamoDB tables the feature server can read"

--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -61,13 +61,7 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile"
             ],
-            "Resource": [
-                "arn:aws:iam::${ACCOUNT_ID}:policy/tecton-*",
-                "arn:aws:iam::${ACCOUNT_ID}:role/tecton-*",
-                "arn:aws:iam::${ACCOUNT_ID}:instance-profile/tecton-*",
-                "arn:aws:iam::${ACCOUNT_ID}:instance-profile/${DEPLOYMENT_NAME}-worker-node",
-                "arn:aws:iam::${ACCOUNT_ID}:instance-profile/${DEPLOYMENT_NAME}-spark-node"
-            ]
+            "Resource": ${INSTANCE_PROFILE_MANAGE_RESOURCES}
 
         },
         {

--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -62,7 +62,7 @@
                 "secretsmanager:TagResource",
                 "secretsmanager:UnTagResource"
             ],
-            "Resource": "arn:aws:secretsmanager:*:*:secret:tecton-${DEPLOYMENT_NAME}/*"
+            "Resource": ${SECRET_RESOURCES}
         },
         {
             "Sid": "ElasticSearch",


### PR DESCRIPTION
Allows deployments that were migrated (e.g. atlassian-production → atlassian2-production) to grant the devops role access to resources still named under the legacy deployment name, without requiring those resources to be renamed.