### PR TITLE
Split off policies to devops_3 to reduce policy size

### DIFF
--- a/roles/roles.tf
+++ b/roles/roles.tf
@@ -247,12 +247,9 @@ resource "aws_iam_policy" "devops_policy_1" {
   policy = templatefile(
     "${path.module}/../templates/devops_policy_1.json",
     {
-      ACCOUNT_ID                        = var.account_id
-      DEPLOYMENT_NAME                   = var.deployment_name
-      DEPLOYMENT_NAME_CONCAT            = format("%.24s", "tecton-${var.deployment_name}")
-      S3_BUCKETS                        = jsonencode(local.s3_buckets)
-      S3_OBJECTS                        = jsonencode(local.s3_objects)
-      INSTANCE_PROFILE_MANAGE_RESOURCES = jsonencode(local.instance_profile_manage_resources)
+      ACCOUNT_ID             = var.account_id
+      DEPLOYMENT_NAME        = var.deployment_name
+      DEPLOYMENT_NAME_CONCAT = format("%.24s", "tecton-${var.deployment_name}")
     }
   )
   tags = local.tags
@@ -264,9 +261,23 @@ resource "aws_iam_policy" "devops_policy_2" {
   policy = templatefile(
     "${path.module}/../templates/devops_policy_2.json",
     {
-      ACCOUNT_ID       = var.account_id
-      DEPLOYMENT_NAME  = var.deployment_name
-      SECRET_RESOURCES = jsonencode(local.secret_resources)
+      ACCOUNT_ID      = var.account_id
+      DEPLOYMENT_NAME = var.deployment_name
+    }
+  )
+  tags = local.tags
+}
+
+# DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_policy" "devops_policy_3" {
+  name = "tecton-${var.deployment_name}-devops-policy-3"
+  policy = templatefile(
+    "${path.module}/../templates/devops_policy_3.json",
+    {
+      S3_BUCKETS                        = jsonencode(local.s3_buckets)
+      S3_OBJECTS                        = jsonencode(local.s3_objects)
+      INSTANCE_PROFILE_MANAGE_RESOURCES = jsonencode(local.instance_profile_manage_resources)
+      SECRET_RESOURCES                  = jsonencode(local.secret_resources)
     }
   )
   tags = local.tags
@@ -340,6 +351,12 @@ resource "aws_iam_role_policy_attachment" "devops_policy_attachment_1" {
 # DEVOPS [Common : Databricks and EMR]
 resource "aws_iam_role_policy_attachment" "devops_policy_attachment_2" {
   policy_arn = aws_iam_policy.devops_policy_2.arn
+  role       = aws_iam_role.devops_role.name
+}
+
+# DEVOPS [Common : Databricks and EMR]
+resource "aws_iam_role_policy_attachment" "devops_policy_attachment_3" {
+  policy_arn = aws_iam_policy.devops_policy_3.arn
   role       = aws_iam_role.devops_role.name
 }
 

--- a/templates/devops_policy_1.json
+++ b/templates/devops_policy_1.json
@@ -2,36 +2,6 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "S3Bucket",
-            "Effect": "Allow",
-            "Action": [
-                "s3:Get*",
-                "s3:ListBucket",
-                "s3:CreateBucket",
-                "s3:DeleteBucket",
-                "s3:DeleteBucketPolicy",
-                "s3:PutBucketPolicy",
-                "s3:PutEncryptionConfiguration",
-                "s3:PutBucketTagging",
-                "s3:PutBucketOwnershipControls",
-                "s3:PutBucketVersioning",
-                "s3:PutLifecycleConfiguration"
-            ],
-            "Resource": ${S3_BUCKETS}
-        },
-        {
-            "Sid": "S3Object",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:DeleteObject",
-                "s3:PutObject",
-                "s3:GetObjectTagging",
-                "s3:PutObjectTagging"
-            ],
-            "Resource": ${S3_OBJECTS}
-        },
-        {
             "Sid": "VerifyPermissionsAndCreateInstanceProfiles",
             "Effect": "Allow",
             "Action": [
@@ -49,20 +19,6 @@
                 "arn:aws:iam::${ACCOUNT_ID}:role/tecton-*",
                 "arn:aws:iam::${ACCOUNT_ID}:instance-profile/tecton-*"
             ]
-        },
-        {
-            "Sid": "ManageInstanceProfilesForTectonRoles",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile",
-                "iam:PassRole",
-                "iam:GetInstanceProfile",
-                "iam:AddRoleToInstanceProfile",
-                "iam:RemoveRoleFromInstanceProfile"
-            ],
-            "Resource": ${INSTANCE_PROFILE_MANAGE_RESOURCES}
-
         },
         {
             "Sid": "ConfigureLoadBalancer",

--- a/templates/devops_policy_2.json
+++ b/templates/devops_policy_2.json
@@ -49,22 +49,6 @@
             ]
         },
         {
-            "Sid": "ManageTectonScopedSecrets",
-            "Effect": "Allow",
-            "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:PutSecretValue",
-                "secretsmanager:CreateSecret",
-                "secretsmanager:DeleteSecret",
-                "secretsmanager:PutSecretValue",
-                "secretsmanager:DescribeSecret",
-                "secretsmanager:GetResourcePolicy",
-                "secretsmanager:TagResource",
-                "secretsmanager:UnTagResource"
-            ],
-            "Resource": ${SECRET_RESOURCES}
-        },
-        {
             "Sid": "ElasticSearch",
             "Action": [
                 "es:CreateDomain",

--- a/templates/devops_policy_3.json
+++ b/templates/devops_policy_3.json
@@ -1,0 +1,65 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "S3Bucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:ListBucket",
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:PutBucketPolicy",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketTagging",
+                "s3:PutBucketOwnershipControls",
+                "s3:PutBucketVersioning",
+                "s3:PutLifecycleConfiguration"
+            ],
+            "Resource": ${S3_BUCKETS}
+        },
+        {
+            "Sid": "S3Object",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject",
+                "s3:GetObjectTagging",
+                "s3:PutObjectTagging"
+            ],
+            "Resource": ${S3_OBJECTS}
+        },
+        {
+            "Sid": "ManageInstanceProfilesForTectonRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:PassRole",
+                "iam:GetInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile"
+            ],
+            "Resource": ${INSTANCE_PROFILE_MANAGE_RESOURCES}
+
+        },
+        {
+            "Sid": "ManageTectonScopedSecrets",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:CreateSecret",
+                "secretsmanager:DeleteSecret",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetResourcePolicy",
+                "secretsmanager:TagResource",
+                "secretsmanager:UnTagResource"
+            ],
+            "Resource": ${SECRET_RESOURCES}
+        }
+    ]
+}


### PR DESCRIPTION
# Split devops IAM policy to avoid 6,144 character size limit

AWS enforces a 6,144 character limit on managed IAM policies. The devops role's devops_policy_1 and devops_policy_2 contain template variables that expand based on the number of satellite_regions and additional_deployment_names. As deployments grow, these policies blow past the limit and fail to apply:

  - devops_policy_1: ${S3_BUCKETS}, ${S3_OBJECTS}, ${INSTANCE_PROFILE_MANAGE_RESOURCES} all expand per region/deployment name
  - devops_policy_2: ${SECRET_RESOURCES} expands per deployment name

## Solution

  Introduce a new devops_policy_3 that consolidates all four high-cardinality statements into a single policy, keeping the static
  portions of policy_1 and policy_2 small and safely within the size limit regardless of scale.

## Changes

  `templates/devops_policy_3.json` (new)
  - Contains the 4 extracted statements: S3Bucket, S3Object, ManageInstanceProfilesForTectonRoles, ManageTectonScopedSecrets

  `templates/devops_policy_1.json`
  - Removed S3Bucket, S3Object, ManageInstanceProfilesForTectonRoles (moved to policy_3)
  - Retains: VerifyPermissionsAndCreateInstanceProfiles, ConfigureLoadBalancer, TerraformReadRolesAndPolicies, DescribeLoadBalancer

  `templates/devops_policy_2.json`
  - Removed ManageTectonScopedSecrets (moved to policy_3)
  - Retains: DynamoDB, CreateServiceLinkedRoles, ElasticSearch, Route53, RDS, ACM, EC2, ServiceDiscovery

  `roles/roles.tf`
  - Added aws_iam_policy.devops_policy_3 and aws_iam_role_policy_attachment.devops_policy_attachment_3
  - Removed high-cardinality template vars from policy_1 and policy_2 templatefile() calls
